### PR TITLE
Adding a helm chart verion of the 102-monitor-namespaces example

### DIFF
--- a/examples/102-monitor-namespaces-chart/Chart.yaml
+++ b/examples/102-monitor-namespaces-chart/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+name: shell-operator-monitor-namespace
+version: 0.1.0
+appVersion: v1.0.0-beta.3
+description: Shell-operator is a tool for running event-driven scripts in a Kubernetes cluster

--- a/examples/102-monitor-namespaces-chart/Dockerfile
+++ b/examples/102-monitor-namespaces-chart/Dockerfile
@@ -1,0 +1,2 @@
+FROM flant/shell-operator:latest
+ADD hooks /hooks

--- a/examples/102-monitor-namespaces-chart/README.md
+++ b/examples/102-monitor-namespaces-chart/README.md
@@ -1,0 +1,51 @@
+## monitor-namespaces-hook example
+
+Example of jqFilter usage to triggered a hook on changing namespace labels.
+
+
+### Run
+
+Build shell-operator image with custom scripts:
+
+```
+$ docker build -t "registry.mycompany.com/shell-operator:monitor-namespaces" .
+$ docker push registry.mycompany.com/shell-operator:monitor-namespaces
+```
+
+Edit image in shell-operator-pod.yaml and apply manifests:
+
+```
+$ kubectl create ns example-monitor-namespaces
+$ kubectl -n example-monitor-namespaces apply -f shell-operator-rbac.yaml  
+$ kubectl -n example-monitor-namespaces apply -f shell-operator-pod.yaml
+```
+
+Create ns to trigget onKuberneteEvent:
+
+```
+$ kubectl create ns foobar
+```
+
+See in logs that hook was run:
+
+```
+$ kubectl -n example-monitor-namespaces logs po/shell-operator
+
+...
+Namespace foobar was created
+...
+```
+
+### cleanup
+
+```
+$ kubectl delete ns/example-monitor-namespaces
+$ docker rmi registry.mycompany.com/shell-operator:monitor-namespaces
+
+```
+
+# Helm usage:
+
+```
+helm template --name shell-operator -f values.yaml ./ | kubectl -n shell-operators apply -f -
+```

--- a/examples/102-monitor-namespaces-chart/hooks/namespace-hook.sh
+++ b/examples/102-monitor-namespaces-chart/hooks/namespace-hook.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+if [[ $1 == "--config" ]] ; then
+  cat <<EOF
+{"onKubernetesEvent":[
+  {"name":"OnCreateDeleteNamespace",
+  "kind": "namespace",
+  "event":["add", "delete"]
+  },
+  {"name":"OnModifiedNamespace",
+  "kind": "namespace",
+  "event":["update"],
+  "jqFilter": ".metadata.labels"
+  }
+]}
+EOF
+else
+  bindingName=$(jq -r '.[0].binding' $BINDING_CONTEXT_PATH)
+  resourceEvent=$(jq -r '.[0].resourceEvent' $BINDING_CONTEXT_PATH)
+  resourceName=$(jq -r '.[0].resourceName' $BINDING_CONTEXT_PATH)
+
+  if [[ $bindingName == "OnModifiedNamespace" ]] ; then
+    echo "Namespace $resourceName labels were modified"
+  else
+    if [[ $resourceEvent == "add" ]] ; then
+      echo "Namespace $resourceName was created"
+    else
+      echo "Namespace $resourceName was deleted"
+    fi
+  fi
+fi

--- a/examples/102-monitor-namespaces-chart/templates/_helpers.tpl
+++ b/examples/102-monitor-namespaces-chart/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "unit.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "unit.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "unit.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/examples/102-monitor-namespaces-chart/templates/hook-configmap.yaml
+++ b/examples/102-monitor-namespaces-chart/templates/hook-configmap.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hook-{{ template "unit.name" . }}
+data:
+  hook.sh: |+
+{{ .Files.Get "hooks/namespace-hook.sh" | indent 4 }}

--- a/examples/102-monitor-namespaces-chart/templates/shell-operator-deployment.yaml
+++ b/examples/102-monitor-namespaces-chart/templates/shell-operator-deployment.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "unit.name" . }}
+  labels:
+    app: shell-operator
+    function: {{ template "unit.name" . }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: shell-operator
+      function: {{ template "unit.name" . }}
+  template:
+    metadata:
+      labels:
+        app: shell-operator
+        function: {{ template "unit.name" . }}
+        deployment-rand: {{ randAlphaNum 10 | quote }}
+    spec:
+      containers:
+      - name: shell-operator
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        volumeMounts:
+        - name: hook-{{ template "unit.name" . }}
+          mountPath: /hooks/
+      serviceAccountName: {{ template "unit.name" . }}
+      volumes:
+      - name: hook-{{ template "unit.name" . }}
+        configMap:
+          name: hook-{{ template "unit.name" . }}
+          defaultMode: 0777

--- a/examples/102-monitor-namespaces-chart/templates/shell-operator-rbac.yaml
+++ b/examples/102-monitor-namespaces-chart/templates/shell-operator-rbac.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "unit.name" . }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ template "unit.name" . }}
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get", "watch", "list"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "unit.name" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "unit.name" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "unit.name" . }}
+    namespace: {{ .Values.namespace }}

--- a/examples/102-monitor-namespaces-chart/values.yaml
+++ b/examples/102-monitor-namespaces-chart/values.yaml
@@ -1,0 +1,8 @@
+---
+namespace: shell-operators
+
+image:
+  repository: flant/shell-operator
+  tag: v1.0.0-beta.3
+  #pullPolicy: IfNotPresent
+  pullPolicy: Always


### PR DESCRIPTION
Signed-off-by: garland <garlandk@gmail.com>

Hi

Would a Helm Chart deploy option be interesting as an example usage?

I found this project and thought it was pretty cool and would be useful.  However, I didn't want to build the docker images when my use case only called for a script to be inserted into the image that you already provide.  

This allows you to not have to build the image and can place the script in the  `hooks` dir and it will mount it inside of the container.

