### PR TITLE
Add an option to specify listening address for HTTP server

### DIFF
--- a/cmd/shell-operator/main.go
+++ b/cmd/shell-operator/main.go
@@ -37,7 +37,7 @@ func main() {
 			// in case if shell-operator is a PID1.
 			go executor.Reap()
 
-			operator.InitHttpServer()
+			operator.InitHttpServer(app.ListenAddress)
 
 			rlog.Infof("%s %s", app.AppName, app.Version)
 

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"gopkg.in/alecthomas/kingpin.v2"
+	"net"
 )
 
 var AppName = "shell-operator"
@@ -15,6 +16,7 @@ var WorkingDir = ""
 var TempDir = "/tmp/shell-operator"
 var KubeContext = ""
 var KubeConfig = ""
+var ListenAddress, _ = net.ResolveTCPAddr("tcp", "0.0.0.0:9115")
 
 // SetupGlobalSettings init global flags with default values
 func SetupGlobalSettings(kpApp *kingpin.Application) {
@@ -43,4 +45,8 @@ func SetupGlobalSettings(kpApp *kingpin.Application) {
 		Default(KubeConfig).
 		StringVar(&KubeConfig)
 
+	kpApp.Flag("listen-address", "Address and port to use for HTTP serving.").
+		Envar("SHELL_OPERATOR_LISTEN_ADDRESS").
+		Default(ListenAddress.String()).
+		TCPVar(&ListenAddress)
 }

--- a/pkg/shell-operator/operator.go
+++ b/pkg/shell-operator/operator.go
@@ -3,6 +3,7 @@ package shell_operator
 import (
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"time"
@@ -342,7 +343,7 @@ func RunMetrics() {
 	}()
 }
 
-func InitHttpServer() {
+func InitHttpServer(listenAddr *net.TCPAddr) {
 	http.HandleFunc("/", func(writer http.ResponseWriter, request *http.Request) {
 		writer.Write([]byte(`<html>
     <head><title>Shell operator</title></head>
@@ -360,8 +361,8 @@ func InitHttpServer() {
 	})
 
 	go func() {
-		rlog.Info("HTTP SERVER Listening on :9115")
-		if err := http.ListenAndServe(":9115", nil); err != nil {
+		rlog.Infof("HTTP SERVER Listening on %s", listenAddr.String())
+		if err := http.ListenAndServe(listenAddr.String(), nil); err != nil {
 			rlog.Errorf("Error starting HTTP server: %s", err)
 		}
 	}()


### PR DESCRIPTION
The issue has arisen, when I had to run multiple shell-operator images in a single pod.