### PR TITLE
Allow subscribing to Kubernetes events by concrete object name

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -107,6 +107,7 @@ Syntax:
           ...
         ],
       },
+      "objectName": "backend-7zxyf",
       "namespaceSelector": {
         "matchNames": ["somenamespace", "proj-production", "proj-stage"],
         "any": true|false,
@@ -138,6 +139,8 @@ Parameters:
 
 - `selector` — [standard](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#labelselector-v1-meta) selector of objects (examples [of use](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels)).
   If the selector is not set, then all objects are selected.
+
+- `objectName` — allows to specify a concrete Kubernetes object name. Can be used with or without `selector`.
 
 - `namespaceSelector` — specifies the filter for selecting namespaces. If you omit it, the events from all namespaces will be monitored.
 

--- a/pkg/hook/kube_event/hooks_controller.go
+++ b/pkg/hook/kube_event/hooks_controller.go
@@ -36,7 +36,7 @@ func (obj *MainKubeEventsHooksController) EnableHooks(hookManager hook.HookManag
 		hmHook, _ := hookManager.GetHook(hookName)
 
 		for _, desc := range MakeKubeEventHookDescriptors(hmHook) {
-			configId, err := eventsManager.Run(desc.EventTypes, desc.Kind, desc.Namespace, desc.Selector, desc.JqFilter, desc.Debug)
+			configId, err := eventsManager.Run(desc.EventTypes, desc.Kind, desc.Namespace, desc.Selector, desc.ObjectName, desc.JqFilter, desc.Debug)
 			if err != nil {
 				return err
 			}
@@ -113,6 +113,7 @@ func ConvertOnKubernetesEventToKubeEventHook(hook *hook.Hook, config kube_events
 		Kind:         config.Kind,
 		Namespace:    namespace,
 		Selector:     config.Selector,
+		ObjectName:   config.ObjectName,
 		JqFilter:     config.JqFilter,
 		AllowFailure: config.AllowFailure,
 		Debug:        !config.DisableDebug,

--- a/pkg/hook/kube_event/kube_event_hook.go
+++ b/pkg/hook/kube_event/kube_event_hook.go
@@ -15,6 +15,7 @@ type KubeEventHook struct {
 	Kind         string
 	Namespace    string
 	Selector     *metav1.LabelSelector
+	ObjectName   string
 	JqFilter     string
 	AllowFailure bool
 	Debug        bool

--- a/pkg/kube_events_manager/kube_event.go
+++ b/pkg/kube_events_manager/kube_event.go
@@ -17,6 +17,7 @@ type OnKubernetesEventConfig struct {
 	EventTypes        []OnKubernetesEventType `json:"event"`
 	Kind              string                  `json:"kind"`
 	Selector          *metav1.LabelSelector   `json:"selector"`
+	ObjectName        string                  `json:"objectName"`
 	NamespaceSelector *KubeNamespaceSelector  `json:"namespaceSelector"`
 	JqFilter          string                  `json:"jqFilter"`
 	AllowFailure      bool                    `json:"allowFailure"`


### PR DESCRIPTION
#### The Problem
1. There are some object that lack labels. For example: Service and corresponding Endpoint `kubernetes` in `default` Namespace. I may have an interest in this exact object (whose name is the same across all Kubernetes clusters on planet Earth), but I don't want to muck around with labelings.
2. If I were to use [resourceNames](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#policyrule-v1-rbac-authorization-k8s-io) field in Role or ClusterRole, I'd find that client-go's Reflector component would fail with an error:
```
E0628 13:53:29.852940       1 reflector.go:125] github.com/flant/shell-operator/pkg/kube_events_manager/kube_events_manager.go:350: Failed to list *unstructured.Unstructured: endpoints is forbidden: User "system:serviceaccount:kube-system:node-local-dns" cannot list resource "endpoints" in API group "" in the namespace "kube-system"
```
#### The Solution
Specify a `FieldSelector` that matches on exact `.metadata.name`. It works great in conjunction with `resourceNames` field and allows for a much more fine-grained event subscriptions.