### PR TITLE
fix: Run kubernetes hooks with Synchronization event after onStartup

### DIFF
--- a/pkg/hook/hooks_queue.go
+++ b/pkg/hook/hooks_queue.go
@@ -1,1 +1,0 @@
-package hook

--- a/pkg/kube_events_manager/kube_events_manager_test.go
+++ b/pkg/kube_events_manager/kube_events_manager_test.go
@@ -22,15 +22,15 @@ import (
 type MockResourceInformer struct {
 }
 
-func (*MockResourceInformer) WithDebugName(string) {
-	return
-}
-
 func (*MockResourceInformer) WithNamespace(string) {
 	return
 }
 
 func (*MockResourceInformer) CreateSharedInformer() error {
+	return nil
+}
+
+func (*MockResourceInformer) GetExistedObjects() []ObjectAndFilterResult {
 	return nil
 }
 

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -12,7 +12,8 @@ type TaskType string
 
 const (
 	// a task to run a particular hook
-	HookRun TaskType = "TASK_HOOK_RUN"
+	HookRun                  TaskType = "TASK_HOOK_RUN"
+	EnableKubernetesBindings TaskType = "TASK_ENABLE_KUBERNETES_BINDINGS"
 
 	// queue control tasks
 	Delay TaskType = "TASK_DELAY"


### PR DESCRIPTION
Run hooks with Synchronization event for kubernetes binding right after hooks with onStartup binding.  Note: `v1` feature.