### PR TITLE
feat: libjq-go to cache compiled jq filters

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,8 +1,8 @@
 name: Main
 on: [push]
 jobs:
-  download_go_modules:
-    name: Download modules
+  prepare_build_dependencies:
+    name: Download modules and build libjq
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.12
@@ -11,83 +11,75 @@ jobs:
           go-version: 1.12
         id: go
 
-      - name: Check out code into the Go module directory
+      - name: Check out shell-operator code
         uses: actions/checkout@v1
 
-      - name: Download modules
-        run: go mod download
+      - name: Download and pack Go modules
+        run: |
+          go mod download
+          tar -czf go_modules.tar.gz -C $HOME/go/pkg/mod .
+          echo Calculate $HOME/go/pkg/mod size:
+          du -sh $HOME/go/pkg/mod
+          echo Calculate go_modules.tar.gz size:
+          du -sh go_modules.tar.gz
         shell: bash
-
-      - name: Pack go modules
-        run: tar -czvf go_modules.tar.gz -C $HOME/go/pkg/mod .
-        shell: bash
-
-
 
       # FIXME: https://github.community/t5/GitHub-Actions/Caching-files-between-GitHub-Action-executions/m-p/30974#M630
-      - name: Upload go modules artifact
+      - name: Upload Go modules artifact
         uses: actions/upload-artifact@master
         with:
           name: go_modules
           path: go_modules.tar.gz
 
-      - name: Build
-        run: go build -v ./cmd/shell-operator
-        shell: bash
+      # Restore libjq-go-build directory from cache or build it, upload it as artifact for other jobs.
+      - name: Extract libjq-go.lock from go.mod
+        run: |
+          grep 'flant/libjq-go' go.mod > libjq-go.lock
+          cat libjq-go.lock
 
-#
-#      - name: Upload binary artifact
-#        uses: actions/upload-artifact@master
-#        with:
-#          name: shell-operator
-#          path: shell-operator.tar.gz
-#
-#      - name: Upload unit test binary artifact
-#        uses: actions/upload-artifact@master
-#        with:
-#          name: unit_test
-#          path: unit_test.tar.gz
-
-
-  build:
-    name: Build and test
-    needs: download_go_modules
-    runs-on: ubuntu-latest
-    steps:
-
-      - name: Set up Go 1.12
-        uses: actions/setup-go@v1
+      - name: Cache libjq libraries
+        id: libjq-cache
+        uses: actions/cache@v1
         with:
-          go-version: 1.12
-        id: go
+          path: libjq
+          key: ${{ runner.os }}-libjq-${{ hashFiles('libjq-go.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-libjq-
 
-      - name: Download go modules artifact
-        uses: actions/download-artifact@master
+      - name: Build libjq libraries
+        if: steps.libjq-cache.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y git ca-certificates tree
+
+          git clone https://github.com/flant/libjq-go libjq-go
+          cd libjq-go
+          git submodule update --init
+          sudo ./scripts/install-libjq-dependencies-ubuntu.sh
+
+          ./scripts/build-libjq-static.sh ${GITHUB_WORKSPACE}/libjq-go ${GITHUB_WORKSPACE}/libjq
+
+          tree  ${GITHUB_WORKSPACE}/libjq
+        shell: bash
+
+      - name: Upload libjq libraries
+        uses: actions/upload-artifact@master
         with:
-          name: go_modules
-          path: .
-
-      - name: Unpack go modules
-        run: mkdir -p $HOME/go/pkg/mod && tar -xzvf go_modules.tar.gz -C $HOME/go/pkg/mod
-        shell: bash
-
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
-
-      - name: Build
-        run: go build -v ./cmd/shell-operator
-        shell: bash
+          name: libjq
+          path: libjq
 
   unit_tests:
     name: Unit tests
-    needs: download_go_modules
+    needs: prepare_build_dependencies
     strategy:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v1
+
       - name: Set up Go 1.12
         uses: actions/setup-go@v1
         with:
@@ -104,22 +96,36 @@ jobs:
         run: mkdir -p $HOME/go/pkg/mod && tar -xzvf go_modules.tar.gz -C $HOME/go/pkg/mod
         shell: bash
 
+      - name: Download libjq artifact
+        uses: actions/download-artifact@master
+        with:
+          name: libjq
+          path: libjq
+
       - name: Prepare environment
         run: |
           export COVERAGE_DIR=$GITHUB_WORKSPACE/tests_coverage/unit_tests/${{ matrix.os }}
           mkdir -p $COVERAGE_DIR
           echo ::set-env name=COVERAGE_DIR::$COVERAGE_DIR
+
+          echo ::set-env name=CGO_ENABLED::1
+
+          CGO_CFLAGS="-I$GITHUB_WORKSPACE/libjq/build/jq/include"
+          echo ::set-env name=CGO_CFLAGS::${CGO_CFLAGS}
+
+          CGO_LDFLAGS="-L$GITHUB_WORKSPACE/libjq/build/onig/lib -L$GITHUB_WORKSPACE/libjq/build/jq/lib"
+          echo ::set-env name=CGO_LDFLAGS::${CGO_LDFLAGS}
+
+          echo ::set-env name=GOOS::linux
+
         shell: bash
 
-      - name: Checkout code
-        uses: actions/checkout@v1
-
-      - name: Test shell-operator packages
+      - name: Run unit tests
         run: go test -tags test -v ./cmd/... ./pkg/... ./test/utils
 
   integration_tests:
     name: Integration tests
-    needs: download_go_modules
+    needs: prepare_build_dependencies
     strategy:
       fail-fast: true
       matrix:
@@ -127,6 +133,9 @@ jobs:
         k8s_version: [1.13, 1.16]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v1
+
       - name: Set up Go 1.12
         uses: actions/setup-go@v1
         with:
@@ -143,14 +152,28 @@ jobs:
         run: mkdir -p $HOME/go/pkg/mod && tar -xzvf go_modules.tar.gz -C $HOME/go/pkg/mod
         shell: bash
 
-      - name: Checkout code
-        uses: actions/checkout@v1
+      - name: Download libjq artifact
+        uses: actions/download-artifact@master
+        with:
+          name: libjq
+          path: libjq
 
       - name: Prepare environment
         run: |
           go build github.com/onsi/ginkgo/ginkgo
           echo ::set-env name=KIND_CLUSTER_VERSION::${{ matrix.k8s_version }}
-# race flag ?
+
+          echo ::set-env name=CGO_ENABLED::1
+
+          CGO_CFLAGS="-I$GITHUB_WORKSPACE/libjq/build/jq/include"
+          echo ::set-env name=CGO_CFLAGS::${CGO_CFLAGS}
+
+          CGO_LDFLAGS="-L$GITHUB_WORKSPACE/libjq/build/onig/lib -L$GITHUB_WORKSPACE/libjq/build/jq/lib"
+          echo ::set-env name=CGO_LDFLAGS::${CGO_LDFLAGS}
+
+          echo ::set-env name=GOOS::linux
+
+      # race flag ?
       - name: Run integration tests
         run: |
           ./ginkgo --tags 'integration test' -p -r test/integration

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,41 @@
-FROM golang:1.12-alpine3.9
+# build libjq
+FROM ubuntu:18.04 AS libjq
+ENV DEBIAN_FRONTEND=noninteractive \
+    DEBCONF_NONINTERACTIVE_SEEN=true \
+    LC_ALL=C.UTF-8 \
+    LANG=C.UTF-8
+
+RUN apt-get update && \
+    apt-get install -y git ca-certificates && \
+    git clone https://github.com/flant/libjq-go /libjq-go && \
+    cd /libjq-go && \
+    git submodule update --init && \
+    /libjq-go/scripts/install-libjq-dependencies-ubuntu.sh && \
+    /libjq-go/scripts/build-libjq-static.sh /libjq-go /out
+
+
+# build shell-operator binary
+FROM golang:1.12 AS shell-operator
 ARG appVersion=latest
-RUN apk --no-cache add git ca-certificates
 
 # Cache-friendly download of go dependencies.
 ADD go.mod go.sum /src/shell-operator/
 WORKDIR /src/shell-operator
 RUN go mod download
 
+COPY --from=libjq /out/build /build
 ADD . /src/shell-operator
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w -X 'github.com/flant/shell-operator/pkg/app.Version=$appVersion'" -o shell-operator ./cmd/shell-operator
 
+RUN CGO_ENABLED=1 \
+    CGO_CFLAGS="-I/build/jq/include" \
+    CGO_LDFLAGS="-L/build/onig/lib -L/build/jq/lib" \
+    GOOS=linux \
+    go build -ldflags="-s -w -X 'github.com/flant/shell-operator/pkg/app.Version=$appVersion'" \
+             -o shell-operator \
+             ./cmd/shell-operator
+
+
+# build final image
 FROM ubuntu:18.04
 RUN apt-get update && \
     apt-get install -y ca-certificates wget jq && \
@@ -17,7 +43,7 @@ RUN apt-get update && \
     wget https://storage.googleapis.com/kubernetes-release/release/v1.13.5/bin/linux/amd64/kubectl -O /bin/kubectl && \
     chmod +x /bin/kubectl && \
     mkdir /hooks
-COPY --from=0 /src/shell-operator /
+COPY --from=shell-operator /src/shell-operator /
 WORKDIR /
 ENV SHELL_OPERATOR_WORKING_DIR /hooks
 ENV LOG_TYPE json

--- a/Dockerfile-alpine3.9
+++ b/Dockerfile-alpine3.9
@@ -1,21 +1,42 @@
-FROM golang:1.12-alpine3.9
+# build libjq
+FROM alpine:3.9 AS libjq
+RUN apk --no-cache add git ca-certificates && \
+    git clone https://github.com/flant/libjq-go /libjq-go && \
+    cd /libjq-go && \
+    git submodule update --init && \
+    /libjq-go/scripts/install-libjq-dependencies-alpine.sh && \
+    /libjq-go/scripts/build-libjq-static.sh /libjq-go /out
+
+
+# build shell-operator binary
+FROM golang:1.12-alpine3.9 AS shell-operator
 ARG appVersion=latest
-RUN apk --no-cache add git ca-certificates
+RUN apk --no-cache add git ca-certificates gcc libc-dev
 
 # Cache-friendly download of go dependencies.
 ADD go.mod go.sum /src/shell-operator/
 WORKDIR /src/shell-operator
 RUN go mod download
 
+COPY --from=libjq /out/build /build
 ADD . /src/shell-operator
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w -X 'github.com/flant/shell-operator/pkg/app.Version=$appVersion'" -o shell-operator ./cmd/shell-operator
 
+RUN CGO_ENABLED=1 \
+    CGO_CFLAGS="-I/build/jq/include" \
+    CGO_LDFLAGS="-L/build/onig/lib -L/build/jq/lib" \
+    GOOS=linux \
+    go build -ldflags="-s -w -X 'github.com/flant/shell-operator/pkg/app.Version=$appVersion'" \
+             -o shell-operator \
+             ./cmd/shell-operator
+
+
+# build final image
 FROM alpine:3.9
 RUN apk --no-cache add ca-certificates jq bash && \
     wget https://storage.googleapis.com/kubernetes-release/release/v1.13.5/bin/linux/amd64/kubectl -O /bin/kubectl && \
     chmod +x /bin/kubectl && \
     mkdir /hooks
-COPY --from=0 /src/shell-operator /
+COPY --from=shell-operator /src/shell-operator /
 WORKDIR /
 ENV SHELL_OPERATOR_WORKING_DIR /hooks
 ENV LOG_TYPE json

--- a/cmd/shell-operator/main.go
+++ b/cmd/shell-operator/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	libjq_go "github.com/flant/libjq-go"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/alecthomas/kingpin.v2"
 
@@ -34,6 +35,9 @@ func main() {
 			// Be a good parent - clean up after the child processes
 			// in case if shell-operator is a PID1.
 			go executor.Reap()
+
+			jqDone := make(chan struct{})
+			go libjq_go.JqCallLoop(jqDone)
 
 			operator.InitHttpServer(app.ListenAddress)
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/flant/shell-operator
 go 1.12
 
 require (
+	github.com/flant/libjq-go v0.0.0-20191126154400-1afb898d97a3 // branch: master
 	github.com/go-openapi/errors v0.19.2
 	github.com/go-openapi/spec v0.19.3
 	github.com/go-openapi/strfmt v0.19.2
@@ -32,3 +33,5 @@ require (
 
 // replace github.com/go-openapi/validate => ../go-openapi-validate
 replace github.com/go-openapi/validate => github.com/flant/go-openapi-validate v0.19.4-0.20190926112101-38fbca4ac77f // branch: fix_in_body
+
+//replace github.com/flant/libjq-go => ../libjq-go

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,12 @@ github.com/evanphx/json-patch v4.5.0+incompatible h1:ouOWdg56aJriqS0huScTkVXPC5I
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/flant/go-openapi-validate v0.19.4-0.20190926112101-38fbca4ac77f h1:HTLgtnIbx2CVK74aTk1D4XbOh6tOHsPShw7UPOJTQzM=
 github.com/flant/go-openapi-validate v0.19.4-0.20190926112101-38fbca4ac77f/go.mod h1:90Vh6jjkTn+OT1Eefm0ZixWNFjhtOH7vS9k0lo6zwJo=
+github.com/flant/libjq-go v0.0.0-20191122114353-2652380c83a5 h1:P/Qo3xVsNXC40HHJzWWeoGMTXBGywPlodr7S4sWTVpw=
+github.com/flant/libjq-go v0.0.0-20191122114353-2652380c83a5/go.mod h1:/BPS5XK5Ak0UPBf4hTu7xHS/D5DeY4qO2Q0KLQPNTRw=
+github.com/flant/libjq-go v0.0.0-20191125115847-289c4784e7f2/go.mod h1:/BPS5XK5Ak0UPBf4hTu7xHS/D5DeY4qO2Q0KLQPNTRw=
+github.com/flant/libjq-go v0.0.0-20191126103323-72666d08402b h1:J9jNyokUmhSx5fT3UqpIAIiPYvdU6dOD92iKMU5YJk8=
+github.com/flant/libjq-go v0.0.0-20191126103323-72666d08402b/go.mod h1:/BPS5XK5Ak0UPBf4hTu7xHS/D5DeY4qO2Q0KLQPNTRw=
+github.com/flant/libjq-go v0.0.0-20191126154400-1afb898d97a3/go.mod h1:/BPS5XK5Ak0UPBf4hTu7xHS/D5DeY4qO2Q0KLQPNTRw=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -20,6 +20,7 @@ var TempDir = "/tmp/shell-operator"
 var KubeContext = ""
 var KubeConfig = ""
 var ListenAddress, _ = net.ResolveTCPAddr("tcp", "0.0.0.0:9115")
+var JqLibraryPath = ""
 
 // Use info level with timestamps and a text output by default
 var LogLevel = "info"
@@ -57,6 +58,11 @@ func SetupGlobalSettings(kpApp *kingpin.Application) {
 		Envar("SHELL_OPERATOR_LISTEN_ADDRESS").
 		Default(ListenAddress.String()).
 		TCPVar(&ListenAddress)
+
+	kpApp.Flag("jq-library-path", "Prepend directory to the search list for jq modules (-L flag). (Can be set with $JQ_LIBRARY_PATH).").
+		Envar("JQ_LIBRARY_PATH").
+		Default(JqLibraryPath).
+		StringVar(&JqLibraryPath)
 
 	kpApp.Flag("log-level", "Logging level: debug, info, error. Default is info.").
 		Envar("LOG_LEVEL").

--- a/pkg/shell-operator/operator.go
+++ b/pkg/shell-operator/operator.go
@@ -43,7 +43,7 @@ var (
 	MetricsStorage *metrics_storage.MetricStorage
 
 	// StopHandleEventsFromManagersCh channel is used to stop loop of the HandleEventsFromManagers.
-	StopHandleEventsFromManagersCh chan struct{}
+	StopHandleEventsFromManagersCh = make(chan struct{}, 1)
 )
 
 var (
@@ -168,6 +168,7 @@ func Stop() {
 	TasksQueue.Push(task.NewTask(task.Stop, "Stop"))
 }
 
+// HandleEventsFromManagers read schedule and kubernetes events and emit tasks to the working queue.
 func HandleEventsFromManagers() {
 	for {
 		select {
@@ -213,6 +214,7 @@ func HandleEventsFromManagers() {
 	}
 }
 
+// TasksRunner is a tasks queue handler
 func TasksRunner() {
 	logEntry := log.WithField("operator.component", "taskRunner")
 	for {


### PR DESCRIPTION
This PR enables use of `jq` as a library with https://github.com/flant/libjq-go to speed up `jqFilter` execution. The dark side is that `shell-operator` should be built with CGO_ENABLED=1 now.