### PR TITLE
feat: generate binding contexts for schedule bindings

### DIFF
--- a/test/hook/context/README.md
+++ b/test/hook/context/README.md
@@ -6,21 +6,24 @@ Usage example:
 1. Declare the hook config
 ```go
 config := `
-{
-  "configVersion":"v1",
-  "kubernetes":[
-	{
-	  "apiVersion":"v1",
-	  "kind":"Pod",
-	  "watchEvent":["Added", "Modified", "Deleted"],
-	  "namespace": {
-		"nameSelector": {
-		  "matchNames": ["default"]
-		}
-	  }
-	}
-  ]
-}`
+configVersion: v1
+schedule:
+- name: every_minute
+  crontab: '* * * * *'
+  includeSnapshotsFrom:
+  - pod
+kubernetes:
+- apiVersion: v1
+  name: pod
+  kind: Pod
+  watchEvent:
+  - Added
+  - Modified
+  - Deleted
+  namespace:
+    nameSelector:
+      matchNames:
+      - default`
 ```
 2. Declare initial state of kubernetes objects
 ```go
@@ -74,4 +77,12 @@ if err != nil {
   return err
 }
 testNewContexts(contexts)
+```
+8. Run schedule to get binding contexts
+```go
+contexts, err = c.RunSchedule("* * * * *")
+if err != nil {
+  return err
+}
+testScheduleContexts(contexts)
 ```

--- a/test/hook/context/generator.go
+++ b/test/hook/context/generator.go
@@ -17,7 +17,8 @@ import (
 	. "github.com/flant/shell-operator/pkg/hook/binding_context"
 	"github.com/flant/shell-operator/pkg/hook/controller"
 	"github.com/flant/shell-operator/pkg/kube"
-	manager "github.com/flant/shell-operator/pkg/kube_events_manager"
+	bindingmanager "github.com/flant/shell-operator/pkg/kube_events_manager"
+	schedulemanager "github.com/flant/shell-operator/pkg/schedule_manager"
 )
 
 var KubeClient kube.KubernetesClient
@@ -34,14 +35,15 @@ func convertBindingContexts(bindingContexts []BindingContext) (string, error) {
 }
 
 type BindingContextController struct {
-	HookCtrl     controller.HookController
-	HookMap      map[string]string
-	HookConfig   string
-	InitialState string
-	Controller   StateController
-	Manager      manager.KubeEventsManager
-	Context      context.Context
-	Cancel       context.CancelFunc
+	HookCtrl        controller.HookController
+	HookMap         map[string]string
+	HookConfig      string
+	InitialState    string
+	Controller      StateController
+	BindingManager  bindingmanager.KubeEventsManager
+	ScheduleManager schedulemanager.ScheduleManager
+	Context         context.Context
+	Cancel          context.CancelFunc
 }
 
 func NewBindingContextController(config, initialState string) (BindingContextController, error) {
@@ -91,10 +93,12 @@ func (b *BindingContextController) Run() (string, error) {
 	fakeDiscovery.FakedServerVersion = &version.Info{GitCommit: "v1.0.0"}
 	fakeDiscovery.Resources = ClusterResources
 
-	b.Manager = manager.NewKubeEventsManager()
-	b.Manager.WithContext(b.Context)
-	b.Manager.WithKubeClient(KubeClient)
+	b.BindingManager = bindingmanager.NewKubeEventsManager()
+	b.BindingManager.WithContext(b.Context)
+	b.BindingManager.WithKubeClient(KubeClient)
 
+	b.ScheduleManager = schedulemanager.NewScheduleManager()
+	b.ScheduleManager.WithContext(b.Context)
 	// Use StateController to apply changes
 	stateController, err := NewStateController(b.InitialState)
 	if err != nil {
@@ -109,12 +113,13 @@ func (b *BindingContextController) Run() (string, error) {
 	}
 
 	b.HookCtrl = controller.NewHookController()
-	b.HookCtrl.InitKubernetesBindings(testHook.GetConfig().OnKubernetesEvents, b.Manager)
+	b.HookCtrl.InitKubernetesBindings(testHook.GetConfig().OnKubernetesEvents, b.BindingManager)
+	b.HookCtrl.InitScheduleBindings(testHook.GetConfig().Schedules, b.ScheduleManager)
+	b.HookCtrl.EnableScheduleBindings()
 
 	testHook.WithHookController(b.HookCtrl)
 
 	bindingContexts := make([]BindingContext, 0)
-
 	err = b.HookCtrl.HandleEnableKubernetesBindings(func(info controller.BindingExecutionInfo) {
 		bindingContexts = append(bindingContexts, b.HookCtrl.UpdateSnapshots(info.BindingContext)...)
 	})
@@ -146,7 +151,7 @@ func (b *BindingContextController) ChangeState(newState ...string) (string, erro
 
 	for {
 		select {
-		case ev := <-b.Manager.Ch():
+		case ev := <-b.BindingManager.Ch():
 			b.HookCtrl.HandleKubeEvent(ev, func(info controller.BindingExecutionInfo) {
 				bindingContexts = append(bindingContexts, info.BindingContext...)
 			})
@@ -159,5 +164,14 @@ func (b *BindingContextController) ChangeState(newState ...string) (string, erro
 			break
 		}
 	}
+	return convertBindingContexts(bindingContexts)
+}
+
+func (b *BindingContextController) RunSchedule(crontab string) (string, error) {
+	bindingContexts := make([]BindingContext, 0)
+
+	b.HookCtrl.HandleScheduleEvent(crontab, func(info controller.BindingExecutionInfo) {
+		bindingContexts = append(bindingContexts, b.HookCtrl.UpdateSnapshots(info.BindingContext)...)
+	})
 	return convertBindingContexts(bindingContexts)
 }

--- a/test/hook/context/generator_test.go
+++ b/test/hook/context/generator_test.go
@@ -1,1 +1,136 @@
 package context
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/flant/shell-operator/pkg/hook/binding_context"
+)
+
+func parseContexts(contexts string) []BindingContext {
+	parsedBindingContexts := []BindingContext{}
+	json.Unmarshal([]byte(contexts), &parsedBindingContexts)
+	return parsedBindingContexts
+}
+
+func Test_BindingContextGenerator(t *testing.T) {
+	t.Run("Binding context generator test", func(t *testing.T) {
+		c, err := NewBindingContextController(`
+configVersion: v1
+kubernetes:
+- apiVersion: v1
+  includeSnapshotsFrom:
+  - selected_pods
+  kind: Pod
+  name: selected_pods
+schedule:
+- name: every_minute
+  crontab: "* * * * *"
+  includeSnapshotsFrom:
+  - selected_pods
+`, `
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod2
+`)
+		assert.Equal(t, err, nil)
+
+		// Synchronization contexts
+		contexts, err := c.Run()
+		assert.Equal(t, err, nil)
+
+		parsedBindingContexts := parseContexts(contexts)
+
+		assert.Equal(t, string(parsedBindingContexts[0].Type), "Synchronization")
+		assert.Equal(t, len(parsedBindingContexts[0].Objects), 2)
+		assert.Equal(t, len(parsedBindingContexts[0].Snapshots["selected_pods"]), 2)
+
+		// Object added
+		contexts, err = c.ChangeState(`
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod2
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod3
+spec:
+  containers: []
+`)
+		assert.Equal(t, err, nil)
+		parsedBindingContexts = parseContexts(contexts)
+
+		assert.Equal(t, string(parsedBindingContexts[0].WatchEvent), "Added")
+		assert.Equal(t, len(parsedBindingContexts[0].Snapshots["selected_pods"]), 3)
+
+		// Object modified
+		contexts, err = c.ChangeState(`
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod2
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod3
+spec:
+  containers:
+  - name: test
+`)
+		assert.Equal(t, err, nil)
+		parsedBindingContexts = parseContexts(contexts)
+
+		assert.Equal(t, string(parsedBindingContexts[0].WatchEvent), "Modified")
+		assert.Equal(t, len(parsedBindingContexts[0].Snapshots["selected_pods"]), 3)
+
+		// Object deleted
+		contexts, err = c.ChangeState(`
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod2
+`)
+		assert.Equal(t, err, nil)
+		parsedBindingContexts = parseContexts(contexts)
+
+		assert.Equal(t, string(parsedBindingContexts[0].WatchEvent), "Deleted")
+		assert.Equal(t, len(parsedBindingContexts[0].Snapshots["selected_pods"]), 2)
+
+		// Run schedule
+		contexts, err = c.RunSchedule("* * * * *")
+		assert.Equal(t, err, nil)
+		parsedBindingContexts = parseContexts(contexts)
+
+		assert.Equal(t, len(parsedBindingContexts[0].Snapshots["selected_pods"]), 2)
+	})
+}


### PR DESCRIPTION
### Description:
The PR adds the ability to generate binding contexts for schedules. 

### Motivation:
After adding includeSnapshotsFrom option to schedule config we need to generate binding contexts for it too to cover hooks, that take Kubernetes cluster state periodically. 