### PR TITLE
fix: jq crashes on try+fromjson expressions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/flant/shell-operator
 go 1.12
 
 require (
-	github.com/flant/libjq-go v1.0.0
+	github.com/flant/libjq-go v1.0.1-0.20200205115921-27e93c18c17f // downgrade jq to 1.6
 	github.com/go-chi/chi v4.0.3+incompatible
 	github.com/go-openapi/errors v0.19.2
 	github.com/go-openapi/spec v0.19.3

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,7 @@ github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLi
 github.com/flant/go-openapi-validate v0.19.4-0.20190926112101-38fbca4ac77f h1:HTLgtnIbx2CVK74aTk1D4XbOh6tOHsPShw7UPOJTQzM=
 github.com/flant/go-openapi-validate v0.19.4-0.20190926112101-38fbca4ac77f/go.mod h1:90Vh6jjkTn+OT1Eefm0ZixWNFjhtOH7vS9k0lo6zwJo=
 github.com/flant/libjq-go v1.0.0/go.mod h1:+SYqi5wsNjtQVlkPg0Ep5IOuN+ydg79Jo/gk4/PuS8c=
+github.com/flant/libjq-go v1.0.1-0.20200205115921-27e93c18c17f/go.mod h1:+SYqi5wsNjtQVlkPg0Ep5IOuN+ydg79Jo/gk4/PuS8c=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=


### PR DESCRIPTION
jq downgraded to tag jq-1.6. More info in issue: https://github.com/flant/libjq-go/issues/6