### PR TITLE
fix: group and version for gvr by kind only

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -282,7 +282,7 @@ func (c *kubernetesClient) APIResource(apiVersion string, kind string) (res meta
 			}
 
 			if equalLowerCasedToOneOf(kind, append(resource.ShortNames, resource.Kind, resource.Name)...) {
-				gv, _ := schema.ParseGroupVersion(apiVersion)
+				gv, _ := schema.ParseGroupVersion(list.GroupVersion)
 				resource.Group = gv.Group
 				resource.Version = gv.Version
 				return resource, nil


### PR DESCRIPTION
KubeClient.GroupVersionResource regression — result gvr with an empty group and version when apiVersion is empty (search by kind).