### PR TITLE
shell-framework: run hooks as subprocesses

### DIFF
--- a/frameworks/shell/hook.sh
+++ b/frameworks/shell/hook.sh
@@ -5,6 +5,7 @@ function hook::run() {
     __config__
     exit 0
   fi
+
   CONTEXT_LENGTH=$(context::global::jq -r 'length')
   for i in `seq 0 $((CONTEXT_LENGTH - 1))`; do
     export BINDING_CONTEXT_CURRENT_INDEX="${i}"
@@ -20,7 +21,6 @@ function hook::run() {
 function hook::_determine_kubernetes_and_scheduler_handlers() {
   if [[ "$BINDING_CONTEXT_CURRENT_BINDING" == "onStartup" ]]; then
     echo __on_startup
-  # if current context has .type field
   elif BINDING_CONTEXT_CURRENT_TYPE=$(context::jq -er '.type'); then
     case "${BINDING_CONTEXT_CURRENT_TYPE}" in
     "Synchronization")
@@ -53,7 +53,7 @@ function hook::_run_first_available_handler() {
 
   for handler in ${HANDLERS}; do
     if type $handler >/dev/null 2>&1; then
-      $handler
+      ($handler) # brackets is to run handler as subprocess
       return $?
     fi
   done

--- a/frameworks/shell/hook.sh
+++ b/frameworks/shell/hook.sh
@@ -53,7 +53,7 @@ function hook::_run_first_available_handler() {
 
   for handler in ${HANDLERS}; do
     if type $handler >/dev/null 2>&1; then
-      ($handler) # brackets is to run handler as subprocess
+      ($handler) # brackets are to run handler as subprocess
       return $?
     fi
   done

--- a/frameworks/shell/hook.sh
+++ b/frameworks/shell/hook.sh
@@ -53,7 +53,7 @@ function hook::_run_first_available_handler() {
 
   for handler in ${HANDLERS}; do
     if type $handler >/dev/null 2>&1; then
-      ($handler) # brackets are to run handler as subprocess
+      ($handler) # brackets are to run handler as a subprocess
       return $?
     fi
   done


### PR DESCRIPTION
To avoid problems with a shared variable namespace in hooks we decided to run every hook handler as a subprocess.