### PR TITLE
Documentation proofreading

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -10,29 +10,25 @@ At startup Shell-operator initializes the hooks:
 
 - The recursive search for hook files is performed in the hooks directory. You can specify it with `--hooks-dir` command-line argument or with the `SHELL_OPERATOR_HOOKS_DIR` environment variable (the default path is `/hooks`).
   - Every executable file found in the path is considered a hook.
-
-- The found hooks are sorted alphabetically according to the directories’ and hooks’ names. Then they are executed with the `--config` flag to get bindings to events in YAML or JSON format.
-
+- Found hooks are sorted alphabetically according to the directories’ and hooks’ names. Then they are executed with the `--config` flag to get bindings to events in YAML or JSON format.
 - If hook's configuration is successful, the working queue named "main" is filled with `onStartup` hooks.
-
 - Then, the "main" queue is filled with `kubernetes` hooks with `Synchronization` [binding context](#binding-context) type, so that each hook receives all existing objects described in hook's configuration.
-
 - After executing `kubernetes` hook with `Synchronization` binding context, Shell-operator starts a monitor of Kubernetes events according to configured `kubernetes` binding.
   - Each monitor stores a *snapshot* — a refreshable list of all Kubernetes objects that match a binding definition.
 
-Next the main cycle is started:
+Next, the main cycle is started:
 
 - Event handler adds hooks to the named queues on events:
   - `kubernetes` hooks are added to the queue when desired [WatchEvent](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#watchevent-v1-meta) is received from Kubernetes,
   - `schedule` hooks are added according to the schedule,
-  - `kubernetes` and `schedule` hooks are added to the "main" queue or to the named queue if `queue` field was specified.
+  - `kubernetes` and `schedule` hooks are added to the "main" queue or the named queue if `queue` field was specified.
 
-- Each named queue has its own queue handler which executes hooks strictly sequentially. If hook fails with an error (non-zero exit code), Shell-operator restarts it (every 5 seconds) until succeeds. In case of an erroneous execution of some hook, when other events occur, the queue will be filled with new tasks, but their execution will be blocked until the failing hook succeeds.
+- Each named queue has its queue handler which executes hooks strictly sequentially. If hook fails with an error (non-zero exit code), Shell-operator restarts it (every 5 seconds) until it succeeds. In case of an erroneous execution of a hook, when other events occur, a queue will be filled with new tasks, but their execution will be blocked until the failing hook succeeds.
   - You can change this behavior for a specific hook by adding `allowFailure: true` to the binding configuration (not available for `onStartup` hooks).
-  
-- Each hook is executed with a binding context, that describes an already occurred event: 
-  - `kubernetes` hook receives `Event` binding context with object related to the event.
-  - `schedule` hook receives a name of triggered schedule binding. 
+
+- Each hook is executed with a binding context, that describes an already occurred event:
+  - `kubernetes` hook receives `Event` binding context with an object related to the event.
+  - `schedule` hook receives a name of triggered schedule binding.
 
 - Several metrics are available for monitoring the activity of the queues and hooks: queues size, number of execution errors for specific hooks, etc. See [METRICS](METRICS.md) for more details.
 
@@ -40,7 +36,7 @@ Next the main cycle is started:
 
 Shell-operator runs the hook with the `--config` flag. In response, the hook should print its event binding configuration to stdout. The response can be in JSON format:
 
-```
+```json
 {
   "configVersion": "v1",
   "onStartup": STARTUP_ORDER,
@@ -57,18 +53,18 @@ Shell-operator runs the hook with the `--config` flag. In response, the hook sho
 
 or in YAML format:
 
-```
+```yaml
 configVersion: v1
 onStartup: ORDER,
 schedule:
 - {SCHEDULE_PARAMETERS}
 - {SCHEDULE_PARAMETERS}
-kubernetes: 
+kubernetes:
 - {KUBERNETES_PARAMETERS}
 - {KUBERNETES_PARAMETERS}
 ```
 
-`configVersion` field specifies a version of configuration schema. The latest schema version is "v1" and it is described below.
+`configVersion` field specifies a version of configuration schema. The latest schema version is **v1** and it is described below.
 
 Event binding is an event type ("onStartup", "schedule" or "kubernetes") plus parameters required for a subscription.
 
@@ -77,24 +73,23 @@ Event binding is an event type ("onStartup", "schedule" or "kubernetes") plus pa
 Use this binding type to execute a hook at the Shell-operator’ startup.
 
 Syntax:
-```
-{
-  "configVersion": "v1",
-  "onStartup": ORDER
-}
+
+```yaml
+configVersion: v1
+onStartup: ORDER
 ```
 
 Parameters:
 
 `ORDER` — an integer value that specifies an execution order. When added to the "main" queue, the hooks will be sorted by this value and then alphabetically by file name.
 
-
 ### schedule
 
 Scheduled execution. You can bind a hook to any number of schedules.
 
 Syntax:
-```
+
+```json
 {
   "configVersion": "v1",
   "schedule": [
@@ -136,7 +131,8 @@ Parameters:
 Run a hook on a Kubernetes object changes.
 
 Syntax:
-```
+
+```json
 {
   "configVersion": "v1",
   "kubernetes": [
@@ -211,24 +207,24 @@ Parameters:
 
 - `apiVersion` is an optional group and version of object API. For example, it is `v1` for core objects (Pod, etc.), `rbac.authorization.k8s.io/v1beta1` for ClusterRole and `monitoring.coreos.com/v1` for prometheus-operator.
 
-- `kind` is the type of a monitored Kubernetes resource. This field is required. CRDs are supported, but resource should be registered in cluster before shell-operator starts. This can be checked with `kubectl api-resources` command. You can specify case-insensitive name, kind or short name in this field. For example, to monitor a DaemonSet these forms are valid:
+- `kind` is the type of a monitored Kubernetes resource. This field is required. CRDs are supported, but the resource should be registered in the cluster before Shell-operator starts. This can be checked with `kubectl api-resources` command. You can specify a case-insensitive name, kind or short name in this field. For example, to monitor a DaemonSet these forms are valid:
 
-```
-"kind": "DaemonSet"
-"kind": "Daemonset"
-"kind": "daemonsets"
-"kind": "DaemonSets"
-"kind": "ds"
-```
+  ```text
+  "kind": "DaemonSet"
+  "kind": "Daemonset"
+  "kind": "daemonsets"
+  "kind": "DaemonSets"
+  "kind": "ds"
+  ```
 
-- `watchEvent` — the list of monitored events (Added, Modified, Deleted). By default all events will be monitored. Docs: [Using API](https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes) [WatchEvent](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#watchevent-v1-meta).
+- `watchEvent` — the list of monitored events (Added, Modified, Deleted). By default, all events will be monitored. Docs: [Using API](https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes) [WatchEvent](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#watchevent-v1-meta).
 
-- `nameSelector` — selector of objects by their name. If this selector is not set, then all objects of specified kind are monitored.
+- `nameSelector` — selector of objects by their name. If this selector is not set, then all objects of a specified Kind are monitored.
 
-- `labelSelector` — [standard](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#labelselector-v1-meta) selector of objects by labels (examples [of use](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels)).
-  If the selector is not set, then all objects of specified kind are monitored.
+- `labelSelector` — [standard](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#labelselector-v1-meta) selector of objects by labels (examples [of use](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels)).
+  If the selector is not set, then all objects of a specified kind are monitored.
 
-- `fieldSelector` — selector of objects by their fields, works like `--field-selector=''` flag of `kubectl`. Supported operators are Equals (or `=`, `==`) and NotEquals (or `!=`) and all expressions are combined with AND. Also note that fieldSelector with 'metadata.name' field is mutually exclusive with nameSelector. There are limits on fields, see [Note](#fieldselector).
+- `fieldSelector` — selector of objects by their fields, works like `--field-selector=''` flag of `kubectl`. Supported operators are Equals (or `=`, `==`) and NotEquals (or `!=`) and all expressions are combined with AND. Also, note that fieldSelector with 'metadata.name' the field is mutually exclusive with nameSelector. There are limits on fields, see [Note](#fieldselector).
 
 - `namespace` — filters to choose namespaces. If omitted, events from all namespaces will be monitored.
 
@@ -236,15 +232,16 @@ Parameters:
 
 - `namespace.labelSelector` — this filter works like `labelSelector` but for namespaces and Shell-operator dynamically subscribes to events from matched namespaces.
 
-- `jqFilter` —  an optional parameter that specifies *event filtering* using [jq syntax](https://stedolan.github.io/jq/manual/). The hook will be triggered on Modified event only if the filter result is changed after the last event. See example [102-monitor-namespaces](examples/102-monitor-namespaces).
+- `jqFilter` —  an optional parameter that specifies event **filtering** using [jq syntax](https://stedolan.github.io/jq/manual/). The hook will be triggered on the "Modified" event only if the filter result is *changed* after the last event. See example [102-monitor-namespaces](examples/102-monitor-namespaces).
 
-- `allowFailure` — if ‘true’, Shell-operator skips the hook execution errors. If ‘false’ or the parameter is not set, the hook is restarted after a 5 seconds delay in case of an error.
+- `allowFailure` — if `true`, Shell-operator skips the hook execution errors. If `false` or the parameter is not set, the hook is restarted after a 5 seconds delay in case of an error.
 
-- `queue` — a name of a separate queue. It can be used to execute long-running hooks in parallel with hooks in "main" queue.
+- `queue` — a name of a separate queue. It can be used to execute long-running hooks in parallel with hooks in the "main" queue.
 
 - `includeSnapshotsFrom` — an array of names of `kubernetes` bindings in a hook. When specified, a list of monitored objects from that bindings will be added to the binding context in a `snapshots` field. Self-include is also possible.
 
 YAML example:
+
 ```yaml
 configVersion: v1
 kubernetes:
@@ -262,15 +259,15 @@ kubernetes:
   includeSnapshotsFrom: ["label-changes-of-mylabel-pods"]
 ```
 
-This hook configuration will execute hook on each change in labels of pods labeled with myLabel=myLabelValue in namespace "default". The binding context will contain all pods with myLabel=myLabelValue from namespace "default".
+This hook configuration will execute hook on each change in labels of pods labeled with `myLabel=myLabelValue` in "default" namespace. The binding context will contain all pods with `myLabel=myLabelValue` from "default" namespace.
 
-#### usage notes
+#### Extra notes
 
-##### default namespace
+##### default Namespace
 
 Unlike `kubectl` you should explicitly define namespace.nameSelector to monitor events from `default` namespace.
 
-```
+```json
       "namespace": {
         "nameSelector": ["default"]
       },
@@ -282,19 +279,19 @@ Shell-operator requires a ServiceAccount with the appropriate [RBAC](https://kub
 
 ##### jqFilter
 
-This filter is used to ignore superfluous "Modified" events, and not to select objects to subscribe to. For example, if the hook is interested in changes of labels, `"jqFilter": ".metadata.labels"` can be used to ignore changes in `.status` or `.metadata.annotations`.
+This filter is used to ignore superfluous "Modified" events, and to *exclude* object from event subscription. For example, if the hook is interested in changes of object's labels, `"jqFilter": ".metadata.labels"` can be used to ignore changes in `.status` or `.metadata.annotations`.
 
 The result of applying the filter to the event's object is passed to the hook in a `filterResult` field of a [binding context](#binding-context).
 
-You can use JQ_LIBRARY_PATH to set a path with jq modules. Also, Shell-operator uses jq release 1.6 so you can check your filters with a binary of that version.
+You can use `JQ_LIBRARY_PATH` environment variable to set a path with `jq` modules. Also, Shell-operator uses `jq` release 1.6 so you can check your filters with a binary of that version.
 
 ##### Added != Object created
 
-Consider that "Added" event is not always equal to "Object created" if labelSelector, fieldSelector or namespace.labelSelector is specified in the `binding`. If objects and/or namespace are updated in Kubernetes, the `binding` may suddenly start matching them, with the "Added" event. The same with "Deleted" event: "Deleted" is not always equal to "Object removed", the object can just move out of scope of selectors.
+Consider that the "Added" event is not always equal to "Object created" if `labelSelector`, `fieldSelector` or `namespace.labelSelector` is specified in the `binding`. If objects and/or namespace are updated in Kubernetes, the `binding` may suddenly start matching them, with the "Added" event. The same with "Deleted" event: "Deleted" is not always equal to "Object removed", the object can just move out of a scope of selectors.
 
 ##### fieldSelector
 
-There is no support of filtering by arbitrary field neither for core resources nor for custom resources (see [issue#53459](https://github.com/kubernetes/kubernetes/issues/53459)). Only `metadata.name` and `metadata.namespace` fields are commonly supported.
+There is no support for filtering by arbitrary field neither for core resources nor for custom resources (see [issue#53459](https://github.com/kubernetes/kubernetes/issues/53459)). Only `metadata.name` and `metadata.namespace` fields are commonly supported.
 
 However fieldSelector can be useful for some resources with extended set of supported fields:
 
@@ -308,10 +305,9 @@ However fieldSelector can be useful for some resources with extended set of supp
 | Job        | status.successful              | [1.16](https://github.com/kubernetes/kubernetes/blob/v1.16.1/pkg/registry/batch/job/strategy.go#L205)        |
 | Node       | spec.unschedulable              | [1.16](https://github.com/kubernetes/kubernetes/blob/v1.16.1/pkg/registry/core/node/strategy.go#L204)        |
 
-
 Example of selecting Pods by 'Running' phase:
 
-```
+```json
 "kind": "Pod",
 "fieldSelector":{
   "matchExpressions":[
@@ -326,36 +322,34 @@ Example of selecting Pods by 'Running' phase:
 
 ##### fieldSelector and labelSelector expressions are ANDed
 
-Objects should match all expressions defined in `fieldSelector` and `labelSelector`, so, for example, multiple `fieldSelector` expressions with "metadata.name" field and different values will not match any object.
+Objects should match all expressions defined in `fieldSelector` and `labelSelector`, so, for example, multiple `fieldSelector` expressions with `metadata.name` field and different values will not match any object.
 
 ## Binding context
 
-When an event associated with a hook is triggered, Shell-operator executes the hook without arguments. The information about the event that led to the hook execution is called the **binding context** and is written in JSON format to a temporary file. The path of this file is available to hook via environment variable `BINDING_CONTEXT_PATH`.
+When an event associated with a hook is triggered, Shell-operator executes the hook without arguments. The information about the event that led to the hook execution is called the **binding context** and is written in JSON format to a temporary file. The path to this file is available to hook via environment variable `BINDING_CONTEXT_PATH`.
 
 Temporary files have unique names to prevent collisions between queues and are deleted after the hook run.
 
  Binging context is a JSON-array of structures with the following fields:
 
 - `binding` is a string from the `name` parameter. If the parameter has not been set in the binding configuration, then strings `schedule` or `kubernetes` are used. For a hook executed at startup, this value is always `onStartup`.
-
 - `snapshots` — binding context for `kubernetes` and `schedule` hooks contains a `snapshots` field if `includeSnapshotsFrom` is defined. `snapshots` object contains a list of objects for each binding name from `includeSnapshotsFrom`. If the list is empty, the named field is omitted.
 
 There are some extra fields for `kubernetes`-type events:
 
 - `type` - "Synchronization" or "Event". "Synchronization" binding context contains all objects that match selectors in a hook's configuration. "Event" binding context contains a watch event type, an event related object and a jq filter result.
-
-- `watchEvent` — the possible value is one of the values you can pass in `watchEvent` binding parameter: “Added”, “Modified” or “Deleted”. This value is set if type is "Event".
-- `object` — the whole object related to the event. It contains the exact copy of the corresponding field in [WatchEvent](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#watchevent-v1-meta) response, so it's the object state **at the moment of the event** (not at the moment of the hook execution).
-- `filterResult` — the result of jq execution with specified `jqFilter` on the abovementioned object. If `jqFilter` is not specified, then `filterResult` is omitted.
+- `watchEvent` — the possible value is one of the values you can pass in `watchEvent` binding parameter: “Added”, “Modified” or “Deleted”. This value is set if the `type` field is set to "Event".
+- `object` — the whole object related to the event. It contains an exact copy of the corresponding field in [WatchEvent](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#watchevent-v1-meta) response, so it's the object state **at the moment of the event** (not at the moment of the hook execution).
+- `filterResult` — the result of `jq` execution with specified `jqFilter` on the abovementioned object. If `jqFilter` is not specified, then `filterResult` is omitted.
 - `objects` — a list of existing objects that match selectors. Each item of this list contains `object` and `filterResult` fields. If the list is empty, the value of `objects` is an empty array.
 
-#### onStartup binding context example
+### `onStartup` binding context example
 
 ```json
 [{ "binding": "onStartup"}]
 ```
 
-#### schedule binding context example
+### `schedule` binding context example
 
 For example, if you have the following configuration in a hook:
 
@@ -367,13 +361,13 @@ schedule:
   allowFailure: true
 ```
 
-... then at 12:02 it will be executed with the following binding context:
+then at 12:02, it will be executed with the following binding context:
 
 ```json
 [{ "binding": "incremental"}]
 ```
 
-#### kubernetes binding context example
+### kubernetes binding context example
 
 A hook can monitor Pods in all namespaces with this simple configuration:
 
@@ -385,7 +379,7 @@ kubernetes:
 
 During startup, the hook will be executed with "Synchronization" binding context:
 
-```
+```json
 [
   {
     "binding": "kubernetes",
@@ -417,9 +411,9 @@ During startup, the hook will be executed with "Synchronization" binding context
 ]
 ```
 
-If pod `pod-321d12` will be added into namespace 'default', then hook will be executed with "Event" binding context:
+If pod `pod-321d12` is then added into namespace 'default', then the hook will be executed with the "Event" binding context:
 
-```
+```json
 [
   {
     "binding": "kubernetes",
@@ -442,7 +436,7 @@ If pod `pod-321d12` will be added into namespace 'default', then hook will be ex
 ]
 ```
 
-#### example of a binding context with included snapshots and jqFilter result
+### An example of a binding context with `includeSnapshotsFrom` and `jqFilter` result
 
 Consider the hook that monitors changes of labels of all Pods and do something interesting on schedule:
 
@@ -459,9 +453,9 @@ kubernetes:
   includeSnapshotsFrom: ["monitor-pods"]
 ```
 
-During startup, the hook will be executed with "Synchronization" binding context with "snapshots" JSON-object:
+During startup, the hook will be executed with the "Synchronization" binding context with `snapshots` JSON object:
 
-```
+```json
 [
   {
     "binding": "kubernetes",
@@ -511,16 +505,16 @@ During startup, the hook will be executed with "Synchronization" binding context
           },
           "filterResult": { ... },
         },
-        ...        
+        ...
       ]
     }
   }
 ]
 ```
 
-If pod `pod-321d12` will be added into namespace 'default', then hook will be executed with "Event" binding context with `object` and `filterResult` fields:
+If pod `pod-321d12` is then added into the "default" namespace, then the hook will be executed with the "Event" binding context with `object` and `filterResult` fields:
 
-```
+```json
 [
   {
     "binding": "kubernetes",
@@ -553,16 +547,16 @@ If pod `pod-321d12` will be added into namespace 'default', then hook will be ex
           },
           "filterResult": { ... },
         },
-        ...        
+        ...
       ]
     }
   }
 ]
 ```
 
-And at 12:02 it will be executed with the following binding context:
+at 12:02, it will be executed with the following binding context:
 
-```
+```json
 [
   {
     "binding": "incremental",
@@ -579,7 +573,7 @@ And at 12:02 it will be executed with the following binding context:
           },
           "filterResult": { ... },
         },
-        ...        
+        ...
       ]
     }
   }

--- a/METRICS.md
+++ b/METRICS.md
@@ -2,18 +2,9 @@
 
 Shell-operator exports Prometheus metrics to the `/metrics` path. The default port is 9115.
 
-__shell_operator_hook_errors{hook="hook-name"}__
+## Metrics
 
-This is the counter of hooks’ execution errors. It only tracks errors of hooks with the disabled `allowFailure` (i.e. respective key is omitted in the configuration or the `allowFailure: false` parameter is set). This metric has a “hook” label with the name of a failed hook.
-
-__shell_operator_hook_allowed_errors{hook="hook-name"}__
-
-This is the counter of hooks’ execution errors. It only tracks errors of hooks that are allowed to exit with an error (the parameter `allowFailure: true` is set in the configuration). The metric has a “hook” label with the name of a failed hook.
-
-__shell_operator_tasks_queue_length__
-
-A gauge showing the length of the working queue. This metric can be used to warn about stuck hooks. It has no labels.
-
-__shell_operator_live_ticks__
-
-A counter that increases every 10 seconds. This metric can be used for alerting about a hung Shell-operator. It has no labels.
+* `shell_operator_hook_errors{hook="hook-name"}` – this is the counter of hooks’ execution errors. It only tracks errors of hooks with the disabled `allowFailure` (i.e. respective key is omitted in the configuration or the `allowFailure: false` parameter is set). This metric has a “hook” label with the name of a failed hook.
+* `shell_operator_hook_allowed_errors{hook="hook-name"}` – this is the counter of hooks’ execution errors. It only tracks errors of hooks that are allowed to exit with an error (the parameter `allowFailure: true` is set in the configuration). The metric has a “hook” label with the name of a failed hook.
+* `shell_operator_tasks_queue_length` – a gauge showing the length of the working queue. This metric can be used to warn about stuck hooks. It has no labels.
+* `shell_operator_live_ticks` – a counter that increases every 10 seconds. This metric can be used for alerting about an unhealthy Shell-operator. It has no labels.

--- a/RUNNING.md
+++ b/RUNNING.md
@@ -1,12 +1,12 @@
-# Running shell-operator
+# Running Shell-operator
 
 ## Configuration
 
 ### Run in a cluster
 
-- Build image from flant/shell-operator:v1.0.0-beta.7, copy your hooks in /hooks directory,
-- Apply RBAC manifests,
-- Apply Pod or Deployment manifest with built image.
+- Build an image from flant/shell-operator:v1.0.0-beta.7, copy your hooks to `/hooks` directory.
+- Apply RBAC manifests.
+- Apply Pod or Deployment manifest with the built image.
 
 More detailed explanation is available in [README](README.md#quickstart), also see [examples](/examples).
 
@@ -22,7 +22,7 @@ It is not recommended for production but can be useful while debugging hooks. A 
 # Start local cluster
 kind create cluster
 
-# Start shell-operator from outside the cluster
+# Start Shell-operator from outside the cluster
 shell-operator start --hooks-dir $(pwd)/hooks --tmp-dir $(pwd)/tmp --log-type color
 
 ```

--- a/examples/001-startup-shell/README.md
+++ b/examples/001-startup-shell/README.md
@@ -4,7 +4,7 @@ Example of a hook written as bash script.
 
 ### run
 
-Build shell-operator image with custom scripts:
+Build Shell-operator image with custom scripts:
 
 ```
 docker build -t "registry.mycompany.com/shell-operator:startup-shell" .


### PR DESCRIPTION
TODO: 

~- [ ] Replace every JSON example with YAML~

There should be a way to properly present available syntax options without resorting to EBNF notation or mocking a JSON document...