### PR TITLE
feat: fail description and count for failed tasks in queue dump

### DIFF
--- a/pkg/hook/controller/schedule_bindings_controller.go
+++ b/pkg/hook/controller/schedule_bindings_controller.go
@@ -19,7 +19,7 @@ type ScheduleBindingToCrontabLink struct {
 	QueueName        string
 }
 
-// KubernetesBindingsController handles kubernetes bindings for one hook.
+// ScheduleBindingsController handles schedule bindings for one hook.
 type ScheduleBindingsController interface {
 	WithScheduleBindings([]ScheduleConfig)
 	WithScheduleManager(schedule_manager.ScheduleManager)

--- a/pkg/shell-operator/operator.go
+++ b/pkg/shell-operator/operator.go
@@ -294,8 +294,8 @@ func (op *ShellOperator) TaskHandler(t task.Task) queue.TaskResult {
 				res.Status = "Success"
 			} else {
 				op.MetricStorage.SendCounter("shell_operator_hook_errors", 1.0, map[string]string{"hook": hookLabel})
-				t.IncrementFailureCount()
-				taskLogEntry.Errorf("Hook failed. Will retry after delay. Failed count is %d. Error: %s", t.GetFailureCount(), err)
+				t.UpdateFailureMessage(err.Error())
+				taskLogEntry.Errorf("Hook failed. Will retry after delay. Failed count is %d. Error: %s", t.GetFailureCount()+1, err)
 				res.Status = "Fail"
 			}
 		} else {
@@ -334,8 +334,8 @@ func (op *ShellOperator) TaskHandler(t task.Task) queue.TaskResult {
 		if err != nil {
 			hookLabel := taskHook.SafeName()
 			op.MetricStorage.SendCounter("shell_operator_hook_errors", 1.0, map[string]string{"hook": hookLabel})
-			t.IncrementFailureCount()
-			taskLogEntry.Errorf("Enable Kubernetes binding for hook failed. Will retry after delay. Failed count is %d. Error: %s", t.GetFailureCount(), err)
+			t.UpdateFailureMessage(err.Error())
+			taskLogEntry.Errorf("Enable Kubernetes binding for hook failed. Will retry after delay. Failed count is %d. Error: %s", t.GetFailureCount()+1, err)
 			res.Status = "Fail"
 		} else {
 			// return Synchronization tasks to add to the queue head.


### PR DESCRIPTION
Example queue dump from addon-operator:

```
DiscoverModulesState:main:::PrepopulateMainQueue:failures 3:module hook --config run problem
```