### PR TITLE
feat: group key to combine tasks in queue into one binding context

### DIFF
--- a/pkg/hook/binding_context/binding_context.go
+++ b/pkg/hook/binding_context/binding_context.go
@@ -17,10 +17,10 @@ type BindingContext struct {
 		JqFilter            string
 		IncludeSnapshots    []string
 		IncludeAllSnapshots bool
-		SkipKey             string
+		Group               string
 	}
 
-	// name of binding or kubeEventType if binding has no 'name' field
+	// name of a binding or a group or kubeEventType if binding has no 'name' field
 	Binding string
 	// additional fields for 'kubernetes' binding
 	Type       KubeEventType
@@ -59,6 +59,11 @@ func (bc BindingContext) MapV1() map[string]interface{} {
 		} else {
 			res["snapshots"] = map[string]string{}
 		}
+	}
+
+	if bc.Metadata.Group != "" {
+		res["binding"] = bc.Metadata.Group
+		return res
 	}
 
 	if bc.Metadata.BindingType != OnKubernetesEvent || bc.Type == "" {

--- a/pkg/hook/config/schemas.go
+++ b/pkg/hook/config/schemas.go
@@ -99,7 +99,7 @@ properties:
             type: string
         queue:
           type: string
-        skipKey:
+        group:
           type: string
   kubernetes:
     title: kubernetes event bindings
@@ -169,7 +169,7 @@ properties:
                     enum: ["=", "==", "Equals", "!=", "NotEquals"]
                   value:
                     type: string
-        skipKey:
+        group:
           type: string
         namespace:
           type: object

--- a/pkg/hook/controller/hook_controller.go
+++ b/pkg/hook/controller/hook_controller.go
@@ -15,6 +15,8 @@ type BindingExecutionInfo struct {
 	IncludeAllSnapshots bool
 	AllowFailure        bool
 	QueueName           string
+	Binding             string
+	Group               string
 }
 
 // В каждый хук надо будет положить этот объект.

--- a/pkg/hook/controller/kubernetes_bindings_controller.go
+++ b/pkg/hook/controller/kubernetes_bindings_controller.go
@@ -21,7 +21,7 @@ type KubernetesBindingToMonitorLink struct {
 	AllowFailure     bool
 	JqFilter         string
 	QueueName        string
-	SkipKey          string
+	Group            string
 }
 
 // KubernetesBindingsController handles kubernetes bindings for one hook.
@@ -85,7 +85,7 @@ func (c *kubernetesBindingsController) EnableKubernetesBindings() ([]BindingExec
 			AllowFailure:     config.AllowFailure,
 			JqFilter:         config.Monitor.JqFilter,
 			QueueName:        config.Queue,
-			SkipKey:          config.SkipKey,
+			Group:            config.Group,
 		}
 
 		// There is no Synchronization event for 'v0' binding configuration.
@@ -143,6 +143,8 @@ func (c *kubernetesBindingsController) HandleEvent(kubeEvent KubeEvent) BindingE
 		IncludeSnapshots: link.IncludeSnapshots,
 		AllowFailure:     link.AllowFailure,
 		QueueName:        link.QueueName,
+		Binding:          link.BindingName,
+		Group:            link.Group,
 	}
 }
 
@@ -190,7 +192,7 @@ func ConvertKubeEventToBindingContext(kubeEvent KubeEvent, link *KubernetesBindi
 		bc.Metadata.JqFilter = link.JqFilter
 		bc.Metadata.BindingType = OnKubernetesEvent
 		bc.Metadata.IncludeSnapshots = link.IncludeSnapshots
-		bc.Metadata.SkipKey = link.SkipKey
+		bc.Metadata.Group = link.Group
 
 		bindingContexts = append(bindingContexts, bc)
 
@@ -205,7 +207,7 @@ func ConvertKubeEventToBindingContext(kubeEvent KubeEvent, link *KubernetesBindi
 			bc.Metadata.JqFilter = link.JqFilter
 			bc.Metadata.BindingType = OnKubernetesEvent
 			bc.Metadata.IncludeSnapshots = link.IncludeSnapshots
-			bc.Metadata.SkipKey = link.SkipKey
+			bc.Metadata.Group = link.Group
 
 			bindingContexts = append(bindingContexts, bc)
 		}

--- a/pkg/hook/controller/schedule_bindings_controller.go
+++ b/pkg/hook/controller/schedule_bindings_controller.go
@@ -15,7 +15,7 @@ type ScheduleBindingToCrontabLink struct {
 	IncludeSnapshots []string
 	AllowFailure     bool
 	QueueName        string
-	SkipKey          string
+	Group            string
 }
 
 // ScheduleBindingsController handles schedule bindings for one hook.
@@ -77,13 +77,15 @@ func (c *scheduleBindingsController) HandleEvent(crontab string) []BindingExecut
 			}
 			bc.Metadata.BindingType = Schedule
 			bc.Metadata.IncludeSnapshots = link.IncludeSnapshots
-			bc.Metadata.SkipKey = link.SkipKey
+			bc.Metadata.Group = link.Group
 
 			info := BindingExecutionInfo{
 				BindingContext:   []BindingContext{bc},
 				IncludeSnapshots: link.IncludeSnapshots,
 				AllowFailure:     link.AllowFailure,
 				QueueName:        link.QueueName,
+				Binding:          link.BindingName,
+				Group:            link.Group,
 			}
 			res = append(res, info)
 		}
@@ -100,7 +102,7 @@ func (c *scheduleBindingsController) EnableScheduleBindings() {
 			IncludeSnapshots: config.IncludeSnapshotsFrom,
 			AllowFailure:     config.AllowFailure,
 			QueueName:        config.Queue,
-			SkipKey:          config.SkipKey,
+			Group:            config.Group,
 		}
 		c.scheduleManager.Add(config.ScheduleEntry)
 	}

--- a/pkg/hook/task_metadata/task_metadata.go
+++ b/pkg/hook/task_metadata/task_metadata.go
@@ -18,6 +18,8 @@ const (
 
 type HookMetadata struct {
 	HookName       string // hook name
+	Binding        string // binding name
+	Group          string
 	BindingType    BindingType
 	BindingContext []BindingContext
 	AllowFailure   bool //Task considered as 'ok' if hook failed. False by default. Can be true for some schedule hooks.
@@ -78,6 +80,13 @@ func (m *HookMetadata) WithAllowFailure(allowFailure bool) *HookMetadata {
 	return m
 }
 
-func (m *HookMetadata) GetDescription() string {
-	return fmt.Sprintf("%s:%s", string(m.BindingType), m.HookName)
+func (m HookMetadata) GetDescription() string {
+	additional := ""
+	if m.Group != "" {
+		additional += ":group=" + m.Group
+	}
+	if m.Binding != "" {
+		additional += ":" + m.Binding
+	}
+	return fmt.Sprintf("%s:%s%s", string(m.BindingType), m.HookName, additional)
 }

--- a/pkg/hook/task_metadata/task_metadata_test.go
+++ b/pkg/hook/task_metadata/task_metadata_test.go
@@ -9,6 +9,8 @@ import (
 	. "github.com/flant/shell-operator/pkg/hook/types"
 
 	"github.com/flant/shell-operator/pkg/task"
+	"github.com/flant/shell-operator/pkg/task/dump"
+	"github.com/flant/shell-operator/pkg/task/queue"
 )
 
 func Test_HookMetadata_Access(t *testing.T) {
@@ -34,4 +36,47 @@ func Test_HookMetadata_Access(t *testing.T) {
 	g.Expect(hm.BindingContext[0].Binding).Should(Equal("each_1_min"))
 	g.Expect(hm.BindingContext[1].Binding).Should(Equal("each_5_min"))
 
+}
+
+func Test_HookMetadata_QueueDump_Task_Description(t *testing.T) {
+	g := NewWithT(t)
+
+	logLabels := map[string]string{
+		"hook": "hook1.sh",
+	}
+	q := queue.NewTasksQueue()
+
+	q.AddLast(task.NewTask(EnableKubernetesBindings).
+		WithMetadata(HookMetadata{
+			HookName: "hook1.sh",
+			Binding:  string(EnableKubernetesBindings),
+		}))
+
+	q.AddLast(task.NewTask(HookRun).
+		WithMetadata(HookMetadata{
+			HookName:    "hook1.sh",
+			BindingType: OnKubernetesEvent,
+			Binding:     "monitor_pods",
+		}).
+		WithLogLabels(logLabels).
+		WithQueueName("main"))
+
+	q.AddLast(task.NewTask(HookRun).
+		WithMetadata(HookMetadata{
+			HookName:     "hook1.sh",
+			BindingType:  Schedule,
+			AllowFailure: true,
+			Binding:      "every 1 sec",
+			Group:        "monitor_pods",
+		}).
+		WithLogLabels(logLabels).
+		WithQueueName("main"))
+
+	queueDump := dump.TaskQueueToText(q)
+
+	g.Expect(queueDump).Should(ContainSubstring("hook1.sh"), "Queue dump should reveal a hook name.")
+	g.Expect(queueDump).Should(ContainSubstring("EnableKubernetesBindings"), "Queue dump should reveal EnableKubernetesBindings.")
+	g.Expect(queueDump).Should(ContainSubstring(":kubernetes:"), "Queue dump should show kubernetes binding.")
+	g.Expect(queueDump).Should(ContainSubstring(":schedule:"), "Queue dump should show schedule binding.")
+	g.Expect(queueDump).Should(ContainSubstring("group=monitor_pods"), "Queue dump should show group name.")
 }

--- a/pkg/hook/types/bindings.go
+++ b/pkg/hook/types/bindings.go
@@ -35,7 +35,7 @@ type ScheduleConfig struct {
 	ScheduleEntry        ScheduleEntry
 	IncludeSnapshotsFrom []string
 	Queue                string
-	SkipKey              string
+	Group                string
 }
 
 type OnKubernetesEventConfig struct {
@@ -43,5 +43,5 @@ type OnKubernetesEventConfig struct {
 	Monitor              *kube_events_manager.MonitorConfig
 	IncludeSnapshotsFrom []string
 	Queue                string
-	SkipKey              string
+	Group                string
 }

--- a/pkg/task/dump/dump.go
+++ b/pkg/task/dump/dump.go
@@ -38,9 +38,11 @@ func TaskQueueSetToText(tqs *queue.TaskQueueSet) string {
 
 	sort.Sort(AsQueueNames(names))
 
-	for _, name := range names {
-		buf.WriteString("\n\n==========\n")
+	for i, name := range names {
 		q := tqs.GetByName(name)
+		if i > 0 {
+			buf.WriteString("==========\n\n")
+		}
 		if q == nil {
 			buf.WriteString(fmt.Sprintf("Queue '%s' is not created\n", name))
 		} else {
@@ -54,11 +56,12 @@ func TaskQueueSetToText(tqs *queue.TaskQueueSet) string {
 // Dump tasks in queue
 func TaskQueueToText(q *queue.TaskQueue) string {
 	var buf strings.Builder
-	buf.WriteString(fmt.Sprintf("Queue '%s': length %d\n", q.Name, q.Length()))
+	buf.WriteString(fmt.Sprintf("Queue '%s': length %d, status: '%s'\n", q.Name, q.Length(), q.Status))
 	buf.WriteString("\n")
 
-	var index int
+	var index = 1
 	q.Iterate(func(task task.Task) {
+		buf.WriteString(fmt.Sprintf("%2d. ", index))
 		buf.WriteString(task.GetDescription())
 		buf.WriteString("\n")
 		index++

--- a/pkg/task/dump/dump_test.go
+++ b/pkg/task/dump/dump_test.go
@@ -4,10 +4,11 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	. "github.com/onsi/gomega"
 )
 
 func Test_Sort_ByNamespaceAndName(t *testing.T) {
+	g := NewWithT(t)
 	sorted := []string{
 		"main",
 		"asd",
@@ -16,7 +17,7 @@ func Test_Sort_ByNamespaceAndName(t *testing.T) {
 		"str",
 	}
 
-	assert.True(t, sort.IsSorted(AsQueueNames(sorted)))
+	g.Expect(sort.IsSorted(AsQueueNames(sorted))).To(BeTrue())
 
 	input := []string{
 		"str",
@@ -29,6 +30,6 @@ func Test_Sort_ByNamespaceAndName(t *testing.T) {
 	sort.Sort(AsQueueNames(input))
 
 	for i, s := range sorted {
-		assert.Equal(t, s, input[i], "input index %d", i)
+		g.Expect(input[i]).Should(Equal(s), "fail on 'input' index %d", i)
 	}
 }


### PR DESCRIPTION
- group key clears all sibling tasks with similar key
- fix panic when queue is not created yet
- fix task description in queue dump: show binding, group, hook name
- show queue status in dump: run/sleep after fail/waiting seconds

_fixes #149 _