### PR TITLE
feat: executeHookOnSynchronization for kubernetes binding

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -146,6 +146,7 @@ Syntax:
       "apiVersion": "v1",
       "kind": "Pod",
       "executeHookOnEvent": [ "Added", "Modified", "Deleted" ],
+      "executeHookOnSynchronization": true|false,
       "nameSelector": {
         "matchNames": ["pod-0", "pod-1"]
       },
@@ -223,6 +224,8 @@ Parameters:
   ```
 
 - `executeHookOnEvent` — the list of events which led to a hook's execution. By default, all events are used to execute a hook: "Added", "Modified" and "Deleted". Docs: [Using API](https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes) [WatchEvent](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#watchevent-v1-meta). Empty array can be used to prevent hook execution, it is useful when binding is used only to define a snapshot.
+
+- `executeHookOnSynchronization` — if `false`, Shell-operator skips the hook execution with Synchronization binding context. See [binding context](#binding-context).
 
 - `nameSelector` — selector of objects by their name. If this selector is not set, then all objects of a specified Kind are monitored.
 

--- a/pkg/hook/config/schemas.go
+++ b/pkg/hook/config/schemas.go
@@ -142,6 +142,8 @@ properties:
           example: ".metadata.labels"
         allowFailure:
           type: boolean
+        executeHookOnSynchronization:
+          type: boolean
         resynchronizationPeriod:
           type: string
         nameSelector:

--- a/pkg/hook/config/validator_test.go
+++ b/pkg/hook/config/validator_test.go
@@ -60,7 +60,8 @@ func Test_Validate_V1_With_Error(t *testing.T) {
   "kubernetes": [
     {
       "name": "monitor pods",
-      "watchEvent": ["Added", "Deleted", "Modified"],
+      "executeHookOnEvent": ["Added", "Deleted", "Modified"],
+      "executeHookOnSynchronization": false,
       "apiVersion": "v1",
       "kind": "Pod",
       "includeSnapshotsFrom": ["monitor pods"],

--- a/pkg/hook/controller/kubernetes_bindings_controller.go
+++ b/pkg/hook/controller/kubernetes_bindings_controller.go
@@ -93,6 +93,11 @@ func (c *kubernetesBindingsController) EnableKubernetesBindings() ([]BindingExec
 			continue
 		}
 
+		// Ignore hooks with disabled execution on Synchronization
+		if !config.ExecuteHookOnSynchronization {
+			continue
+		}
+
 		info := c.HandleEvent(*firstKubeEvent)
 		res = append(res, info)
 	}

--- a/pkg/hook/hook_config.go
+++ b/pkg/hook/hook_config.go
@@ -82,22 +82,23 @@ type KubeNamespaceSelectorV0 struct {
 
 // version 1 of kubernetes event configuration
 type OnKubernetesEventConfigV1 struct {
-	Name                    string                   `json:"name,omitempty"`
-	WatchEventTypes         []WatchEventType         `json:"watchEvent,omitempty"`
-	ExecuteHookOnEvents     []WatchEventType         `json:"executeHookOnEvent,omitempty"`
-	Mode                    KubeEventMode            `json:"mode,omitempty"`
-	ApiVersion              string                   `json:"apiVersion,omitempty"`
-	Kind                    string                   `json:"kind,omitempty"`
-	NameSelector            *KubeNameSelectorV1      `json:"nameSelector,omitempty"`
-	LabelSelector           *metav1.LabelSelector    `json:"labelSelector,omitempty"`
-	FieldSelector           *KubeFieldSelectorV1     `json:"fieldSelector,omitempty"`
-	Namespace               *KubeNamespaceSelectorV1 `json:"namespace,omitempty"`
-	JqFilter                string                   `json:"jqFilter,omitempty"`
-	AllowFailure            bool                     `json:"allowFailure,omitempty"`
-	ResynchronizationPeriod string                   `json:"resynchronizationPeriod,omitempty"`
-	IncludeSnapshotsFrom    []string                 `json:"includeSnapshotsFrom,omitempty"`
-	Queue                   string                   `json:"queue,omitempty"`
-	Group                   string                   `json:"group,omitempty"`
+	Name                         string                   `json:"name,omitempty"`
+	WatchEventTypes              []WatchEventType         `json:"watchEvent,omitempty"`
+	ExecuteHookOnEvents          []WatchEventType         `json:"executeHookOnEvent,omitempty"`
+	ExecuteHookOnSynchronization string                   `json:"executeHookOnSynchronization,omitempty"`
+	Mode                         KubeEventMode            `json:"mode,omitempty"`
+	ApiVersion                   string                   `json:"apiVersion,omitempty"`
+	Kind                         string                   `json:"kind,omitempty"`
+	NameSelector                 *KubeNameSelectorV1      `json:"nameSelector,omitempty"`
+	LabelSelector                *metav1.LabelSelector    `json:"labelSelector,omitempty"`
+	FieldSelector                *KubeFieldSelectorV1     `json:"fieldSelector,omitempty"`
+	Namespace                    *KubeNamespaceSelectorV1 `json:"namespace,omitempty"`
+	JqFilter                     string                   `json:"jqFilter,omitempty"`
+	AllowFailure                 bool                     `json:"allowFailure,omitempty"`
+	ResynchronizationPeriod      string                   `json:"resynchronizationPeriod,omitempty"`
+	IncludeSnapshotsFrom         []string                 `json:"includeSnapshotsFrom,omitempty"`
+	Queue                        string                   `json:"queue,omitempty"`
+	Group                        string                   `json:"group,omitempty"`
 }
 
 type KubeNameSelectorV1 NameSelector
@@ -302,6 +303,12 @@ func (c *HookConfig) ConvertAndCheckV1() (err error) {
 			kubeConfig.Queue = kubeCfg.Queue
 		}
 		kubeConfig.Group = kubeCfg.Group
+
+		if kubeCfg.ExecuteHookOnSynchronization == "false" {
+			kubeConfig.ExecuteHookOnSynchronization = false
+		} else {
+			kubeConfig.ExecuteHookOnSynchronization = true
+		}
 
 		c.OnKubernetesEvents = append(c.OnKubernetesEvents, kubeConfig)
 	}

--- a/pkg/hook/types/bindings.go
+++ b/pkg/hook/types/bindings.go
@@ -40,8 +40,9 @@ type ScheduleConfig struct {
 
 type OnKubernetesEventConfig struct {
 	CommonBindingConfig
-	Monitor              *kube_events_manager.MonitorConfig
-	IncludeSnapshotsFrom []string
-	Queue                string
-	Group                string
+	Monitor                      *kube_events_manager.MonitorConfig
+	IncludeSnapshotsFrom         []string
+	Queue                        string
+	Group                        string
+	ExecuteHookOnSynchronization bool
 }

--- a/pkg/shell-operator/operator.go
+++ b/pkg/shell-operator/operator.go
@@ -328,7 +328,7 @@ func (op *ShellOperator) TaskHandler(t task.Task) queue.TaskResult {
 
 		hookRunTasks := []task.Task{}
 
-		// Run hook with Synchronization binding context. Ignore queue name here, execute in main queue.
+		// Run hook for each binding with Synchronization binding context. Ignore queue name here, execute in main queue.
 		err := taskHook.HookController.HandleEnableKubernetesBindings(func(info controller.BindingExecutionInfo) {
 			newTask := task.NewTask(HookRun).
 				WithMetadata(HookMetadata{


### PR DESCRIPTION
To define a binding that only needed to catch a snapshot and do not require a hook execution:

```yaml
configVersion: v1
kubernetes:
- name: pods-snapshot
  kind: Pod
  executeHookOnEvent: []
  executeHookOnSynchronization: false
schedule:
- name: every_1_min
  crontab: "* * * * *"
  includeSnapshotsFrom: ["pods-snapshots"]
```

A hook with this configuration will be executed every 1 minute with pods. And will _not_ be executed on kubernetes event or after onStartup.
