### PR TITLE
feat: allow to send metrics from hooks

### DIFF
--- a/METRICS.md
+++ b/METRICS.md
@@ -8,3 +8,28 @@ Shell-operator exports Prometheus metrics to the `/metrics` path. The default po
 * `shell_operator_hook_allowed_errors{hook="hook-name"}` – this is the counter of hooks’ execution errors. It only tracks errors of hooks that are allowed to exit with an error (the parameter `allowFailure: true` is set in the configuration). The metric has a “hook” label with the name of a failed hook.
 * `shell_operator_tasks_queue_length` – a gauge showing the length of the working queue. This metric can be used to warn about stuck hooks. It has no labels.
 * `shell_operator_live_ticks` – a counter that increases every 10 seconds. This metric can be used for alerting about an unhealthy Shell-operator. It has no labels.
+
+## Custom metrics
+
+Hooks can export metrics by writing a set of operation on JSON format into $METRICS_PATH file.
+
+Operation to increase a counter:
+
+```json
+{"name":"metric_name","add":1,"labels":{"label1":"value1"}}
+```
+
+Operation to set a value for a gauge:
+
+```json
+{"name":"metric_name","set":33,"labels":{"label1":"value1"}}
+```
+
+Labels are not required, but Shell-operator adds a `hook` label.
+
+Several metrics can be expored at once. For example, this script will create 2 metrics:
+
+```
+echo '{"name":"hook_metric_count","add":1,"labels":{"label1":"value1"}}' >> $METRICS_PATH
+echo '{"name":"hook_metrics_items","add":1,"labels":{"label1":"value1"}}' >> $METRICS_PATH
+```

--- a/go.sum
+++ b/go.sum
@@ -99,6 +99,7 @@ github.com/flant/go-openapi-validate v0.19.4-0.20200313141509-0c0fba4d39e1/go.mo
 github.com/flant/libjq-go v1.0.1-0.20200205115921-27e93c18c17f h1:3tmztWJjf61sHfHYLSMi5TDdz5jtmcVqe43PSwsxNvE=
 github.com/flant/libjq-go v1.0.1-0.20200205115921-27e93c18c17f/go.mod h1:+SYqi5wsNjtQVlkPg0Ep5IOuN+ydg79Jo/gk4/PuS8c=
 github.com/flant/libjq-go v1.6.1-0.20200331115542-04a1a2e80daa/go.mod h1:+SYqi5wsNjtQVlkPg0Ep5IOuN+ydg79Jo/gk4/PuS8c=
+github.com/flant/libjq-go v1.6.1-0.20200401092614-198670408da1 h1:pOPBJDB7PZz/SKa13mlR3bvkRJ0KWKRe6v+KZOObkKw=
 github.com/flant/libjq-go v1.6.1-0.20200401092614-198670408da1/go.mod h1:+SYqi5wsNjtQVlkPg0Ep5IOuN+ydg79Jo/gk4/PuS8c=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/pkg/metrics_storage/metric_operation.go
+++ b/pkg/metrics_storage/metric_operation.go
@@ -1,0 +1,50 @@
+package metrics_storage
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+)
+
+type MetricOperation struct {
+	Name   string            `json:"name"`
+	Add    *float64          `json:"add,omitempty"`
+	Set    *float64          `json:"set,omitempty"`
+	Labels map[string]string `json:"labels"`
+}
+
+func MetricOperationsFromReader(r io.Reader) ([]MetricOperation, error) {
+	var operations = make([]MetricOperation, 0)
+
+	dec := json.NewDecoder(r)
+	for {
+		var metricOperation MetricOperation
+		if err := dec.Decode(&metricOperation); err == io.EOF {
+			break
+		} else if err != nil {
+			return nil, err
+		}
+
+		operations = append(operations, metricOperation)
+	}
+
+	return operations, nil
+}
+
+func MetricOperationsFromBytes(data []byte) ([]MetricOperation, error) {
+	return MetricOperationsFromReader(bytes.NewReader(data))
+}
+
+func MetricOperationsFromFile(filePath string) ([]MetricOperation, error) {
+	data, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read %s: %s", filePath, err)
+	}
+
+	if len(data) == 0 {
+		return nil, nil
+	}
+	return MetricOperationsFromBytes(data)
+}

--- a/pkg/shell-operator/operator.go
+++ b/pkg/shell-operator/operator.go
@@ -294,7 +294,14 @@ func (op *ShellOperator) TaskHandler(t task.Task) queue.TaskResult {
 			}
 		}
 
-		err := taskHook.Run(hookMeta.BindingType, hookMeta.BindingContext, hookLogLabels)
+		metrics, err := taskHook.Run(hookMeta.BindingType, hookMeta.BindingContext, hookLogLabels)
+
+		if err == nil {
+			err = op.MetricStorage.SendBatch(metrics, map[string]string{
+				"hook": hookMeta.HookName,
+			})
+		}
+
 		if err != nil {
 			hookLabel := taskHook.SafeName()
 


### PR DESCRIPTION
Use METRICS_PATH file to send operations in JSON format.

Operation add a counter:
{"name":"metric_name","add":1,"labels":{"label1":"value1"}}

Operation to set a gauge value:
{"name":"metric_name","set":33,"labels":{"label1":"value1"}}

labels are optional.