### PR TITLE
Fix example pods-hook.sh YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Let's create a small operator that will watch for all Pods in all Namespaces and
 if [[ $1 == "--config" ]] ; then
   cat <<EOF
 configVersion: v1
-kubernetes":
+kubernetes:
 - apiVersion: v1
   kind: Pod
   executeHookOnEvent: ["Added"]


### PR DESCRIPTION
Remove stray `"` from the README example to avoid the following error:
> MAIN Fatal: initialize hook manager: creating hook 'pods-hook.sh': load hook 'pods-hook.sh' config: 1 error occurred:\n\t* .kubernetes\" is a forbidden property\n\n\nhook --config output: configVersion: v1\nkubernetes\":\n- apiVersion: v1\n  kind: Pod\n  executeHookOnEvent: [\"Added\"]\n\n