### PR TITLE
feat: new property to remove full objects from snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,23 +158,20 @@ Every hook should respond with JSON or YAML configuration of bindings when execu
 
 This binding defines a subset of Kubernetes objects that Shell-operator will monitor and a [jq](https://github.com/stedolan/jq/) expression to filter their properties. Read more about `onKubernetesEvent` bindings [here](HOOKS.md#kubernetes).
 
-Example of JSON output from `hook --config`:
+Example of YAML output from `hook --config`:
 
-```json
-{
-  "configVersion": "v1",
-  "kubernetes": [
-    {
-      "name":"Execute on changes of namespace labels",
-      "kind": "namespace",
-      "executeHookOnEvent":["Modified"],
-      "jqFilter":".metadata.labels"
-    }
-  ]
-}
+```yaml
+configVersion: v1
+kubernetes:
+- name: execute_on_changes_of_namespace_labels
+  kind: Namespace
+  executeHookOnEvent: ["Modified"]
+  jqFilter: ".metadata.labels"
 ```
 
 > Note: it is possible to watch Custom Defined Resources, just use proper values for `apiVersion` and `kind` fields.
+
+> Note: return configuration as JSON is also possible as JSON is a subset of YAML.
 
 ### onStartup
 

--- a/go.sum
+++ b/go.sum
@@ -101,6 +101,7 @@ github.com/flant/libjq-go v1.0.1-0.20200205115921-27e93c18c17f/go.mod h1:+SYqi5w
 github.com/flant/libjq-go v1.6.1-0.20200331115542-04a1a2e80daa/go.mod h1:+SYqi5wsNjtQVlkPg0Ep5IOuN+ydg79Jo/gk4/PuS8c=
 github.com/flant/libjq-go v1.6.1-0.20200401092614-198670408da1 h1:pOPBJDB7PZz/SKa13mlR3bvkRJ0KWKRe6v+KZOObkKw=
 github.com/flant/libjq-go v1.6.1-0.20200401092614-198670408da1/go.mod h1:+SYqi5wsNjtQVlkPg0Ep5IOuN+ydg79Jo/gk4/PuS8c=
+github.com/flant/libjq-go v1.6.1 h1:zEnucbRkoF3ytDWdK2GkS/iz6u7Hjd0LYPu/oEFaNJI=
 github.com/flant/libjq-go v1.6.1/go.mod h1:+SYqi5wsNjtQVlkPg0Ep5IOuN+ydg79Jo/gk4/PuS8c=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/pkg/hook/config/schemas.go
+++ b/pkg/hook/config/schemas.go
@@ -140,6 +140,8 @@ properties:
         jqFilter:
           type: string
           example: ".metadata.labels"
+        keepFullObjectsInMemory:
+          type: boolean
         allowFailure:
           type: boolean
         executeHookOnSynchronization:

--- a/pkg/hook/hook_config.go
+++ b/pkg/hook/hook_config.go
@@ -87,6 +87,7 @@ type OnKubernetesEventConfigV1 struct {
 	ExecuteHookOnEvents          []WatchEventType         `json:"executeHookOnEvent,omitempty"`
 	ExecuteHookOnSynchronization string                   `json:"executeHookOnSynchronization,omitempty"`
 	WaitForSynchronization       string                   `json:"waitForSynchronization,omitempty"`
+	KeepFullObjectsInMemory      string                   `json:"keepFullObjectsInMemory,omitempty"`
 	Mode                         KubeEventMode            `json:"mode,omitempty"`
 	ApiVersion                   string                   `json:"apiVersion,omitempty"`
 	Kind                         string                   `json:"kind,omitempty"`
@@ -307,18 +308,24 @@ func (c *HookConfig) ConvertAndCheckV1() (err error) {
 		}
 		kubeConfig.Group = kubeCfg.Group
 
+		// ExecuteHookOnSynchronization is enabled by default.
+		kubeConfig.ExecuteHookOnSynchronization = true
 		if kubeCfg.ExecuteHookOnSynchronization == "false" {
 			kubeConfig.ExecuteHookOnSynchronization = false
-		} else {
-			kubeConfig.ExecuteHookOnSynchronization = true
 		}
 
-		// Disable WaitForSynchronization makes sense only for named queues.
+		// WaitForSynchronization is enabled by default. It can be disabled only for named queues.
+		kubeConfig.WaitForSynchronization = true
 		if kubeCfg.WaitForSynchronization == "false" && kubeCfg.Queue != "" {
 			kubeConfig.WaitForSynchronization = false
-		} else {
-			kubeConfig.WaitForSynchronization = true
 		}
+
+		// KeepFullObjectsInMemory is enabled by default.
+		kubeConfig.KeepFullObjectsInMemory = true
+		if kubeCfg.KeepFullObjectsInMemory == "false" {
+			kubeConfig.KeepFullObjectsInMemory = false
+		}
+		kubeConfig.Monitor.KeepFullObjectsInMemory = kubeConfig.KeepFullObjectsInMemory
 
 		c.OnKubernetesEvents = append(c.OnKubernetesEvents, kubeConfig)
 	}

--- a/pkg/hook/types/bindings.go
+++ b/pkg/hook/types/bindings.go
@@ -46,4 +46,5 @@ type OnKubernetesEventConfig struct {
 	Group                        string
 	ExecuteHookOnSynchronization bool
 	WaitForSynchronization       bool
+	KeepFullObjectsInMemory      bool
 }

--- a/pkg/kube_events_manager/monitor_config.go
+++ b/pkg/kube_events_manager/monitor_config.go
@@ -17,16 +17,17 @@ type MonitorConfig struct {
 		LogLabels    map[string]string
 		MetricLabels map[string]string
 	}
-	EventTypes        []WatchEventType
-	ApiVersion        string
-	Kind              string
-	NameSelector      *NameSelector
-	NamespaceSelector *NamespaceSelector
-	LabelSelector     *metav1.LabelSelector
-	FieldSelector     *FieldSelector
-	JqFilter          string
-	LogEntry          *log.Entry
-	Mode              KubeEventMode
+	EventTypes              []WatchEventType
+	ApiVersion              string
+	Kind                    string
+	NameSelector            *NameSelector
+	NamespaceSelector       *NamespaceSelector
+	LabelSelector           *metav1.LabelSelector
+	FieldSelector           *FieldSelector
+	JqFilter                string
+	LogEntry                *log.Entry
+	Mode                    KubeEventMode
+	KeepFullObjectsInMemory bool
 }
 
 func (c *MonitorConfig) WithEventTypes(types []WatchEventType) *MonitorConfig {

--- a/pkg/kube_events_manager/util.go
+++ b/pkg/kube_events_manager/util.go
@@ -38,6 +38,7 @@ func ApplyJqFilter(jqFilter string, obj *unstructured.Unstructured) (*ObjectAndF
 	if err != nil {
 		return nil, err
 	}
+	res.ObjectBytes = int64(len(data))
 
 	if jqFilter == "" {
 		res.Metadata.Checksum = utils_checksum.CalculateChecksum(string(data))


### PR DESCRIPTION
- keepFullObjectsInMemory can be used to keep only filterResult for binding context.
- changes and improvements in documentation.
- new metrics to monitor snapshots: cached objects count and size in bytes.