### PR TITLE
feat: separate port for hook metrics

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -16,6 +16,7 @@ var TempDir = "/tmp/shell-operator"
 
 var ListenAddress = "0.0.0.0"
 var ListenPort = "9115"
+var HookMetricsListenPort = ""
 
 var PrometheusMetricsPrefix = "shell_operator_"
 
@@ -44,6 +45,11 @@ func DefineStartCommandFlags(kpApp *kingpin.Application, cmd *kingpin.CmdClause)
 		Envar("SHELL_OPERATOR_PROMETHEUS_METRICS_PREFIX").
 		Default(PrometheusMetricsPrefix).
 		StringVar(&PrometheusMetricsPrefix)
+
+	cmd.Flag("hook-metrics-listen-port", "Port to use to serve hooks’ custom metrics to Prometheus. Can be set with $SHELL_OPERATOR_HOOK_METRICS_LISTEN_PORT. Equal to listen-port if empty.").
+		Envar("SHELL_OPERATOR_HOOK_METRICS_LISTEN_PORT").
+		Default(HookMetricsListenPort).
+		StringVar(&HookMetricsListenPort)
 
 	DefineKubeClientFlags(cmd)
 	DefineJqFlags(cmd)

--- a/pkg/hook/hook_manager.go
+++ b/pkg/hook/hook_manager.go
@@ -146,6 +146,7 @@ func (hm *hookManager) loadHook(hookPath string) (hook *Hook, err error) {
 		kubeCfg.Monitor.Metadata.MetricLabels = map[string]string{
 			"hook":    hook.Name,
 			"binding": kubeCfg.BindingName,
+			"queue":   kubeCfg.Queue,
 		}
 	}
 

--- a/pkg/metric_storage/vault/vault.go
+++ b/pkg/metric_storage/vault/vault.go
@@ -13,6 +13,7 @@ import (
 type GroupedVault struct {
 	collectors map[string]ConstMetricCollector
 	mtx        sync.Mutex
+	Registerer prometheus.Registerer
 }
 
 func NewGroupedVault() *GroupedVault {
@@ -38,7 +39,7 @@ func (v *GroupedVault) GetOrCreateCounterCollector(name string, labelNames []str
 	collector, ok := v.collectors[name]
 	if !ok {
 		collector = NewConstCounterCollector(name, labelNames)
-		if err := prometheus.Register(collector); err != nil {
+		if err := v.Registerer.Register(collector); err != nil {
 			return nil, fmt.Errorf("counter '%s' %v registration: %v", name, labelNames, err)
 		}
 		v.collectors[name] = collector
@@ -55,7 +56,7 @@ func (v *GroupedVault) GetOrCreateGaugeCollector(name string, labelNames []strin
 	collector, ok := v.collectors[name]
 	if !ok {
 		collector = NewConstGaugeCollector(name, labelNames)
-		if err := prometheus.Register(collector); err != nil {
+		if err := v.Registerer.Register(collector); err != nil {
 			return nil, fmt.Errorf("gauge '%s' %v registration: %v", name, labelNames, err)
 		}
 		v.collectors[name] = collector

--- a/pkg/metric_storage/vault/vault_test.go
+++ b/pkg/metric_storage/vault/vault_test.go
@@ -19,6 +19,7 @@ func Test_CounterAdd(t *testing.T) {
 	log.SetOutput(buf)
 
 	v := NewGroupedVault()
+	v.Registerer = prometheus.DefaultRegisterer
 
 	v.CounterAdd("group1", "metric_total", 1.0, map[string]string{"lbl": "val"})
 


### PR DESCRIPTION
- hook-metrics-listen-port flag to specify a listen port for hook metrics
- fix labels cardinality for kube_event_manager metrics