### PR TITLE
feat: no cgo build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	k8s.io/client-go v0.17.0
 	k8s.io/klog v1.0.0
 	sigs.k8s.io/kind v0.7.0
-	sigs.k8s.io/yaml v1.1.1-0.20191128155103-745ef44e09d6 // branch master, with fixes in yaml.v2.2.7
+	sigs.k8s.io/yaml v1.2.0
 )
 
 // replace github.com/go-openapi/validate => ../go-openapi-validate

--- a/pkg/jq/cgo_filter.go
+++ b/pkg/jq/cgo_filter.go
@@ -1,0 +1,27 @@
+// +build cgo
+
+package jq
+
+import (
+	"fmt"
+	"os"
+
+	. "github.com/flant/libjq-go"
+)
+
+// runJqFilter uses libjq-go filter if CGO is enabled and
+// uses exec filter if $JQ_EXEC is set to "yes".
+func runJqFilter(jqFilter string, jsonData []byte, libPath string) (result string, err error) {
+	if os.Getenv("JQ_EXEC") == "yes" {
+		return jqFilterExec(jqFilter, jsonData, libPath)
+	}
+	return jqFilterLibJqGo(jqFilter, jsonData, libPath)
+}
+
+func jqFilterLibJqGo(jqFilter string, jsonData []byte, libPath string) (result string, err error) {
+	result, err = Jq().WithLibPath(libPath).Program(jqFilter).Cached().Run(string(jsonData))
+	if err != nil {
+		return "", fmt.Errorf("libjq filter '%s': '%s'", jqFilter, err)
+	}
+	return
+}

--- a/pkg/jq/exec_filter.go
+++ b/pkg/jq/exec_filter.go
@@ -1,0 +1,40 @@
+package jq
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/flant/shell-operator/pkg/executor"
+)
+
+func jqFilterExec(jqFilter string, jsonData []byte, libPath string) (result string, err error) {
+	var cmd *exec.Cmd
+	if libPath == "" {
+		cmd = exec.Command("/usr/bin/jq", jqFilter)
+	} else {
+		cmd = exec.Command("/usr/bin/jq", "-L", libPath, jqFilter)
+	}
+
+	var stdinBuf bytes.Buffer
+	_, err = stdinBuf.WriteString(string(jsonData))
+	if err != nil {
+		panic(err)
+	}
+	cmd.Stdin = &stdinBuf
+	var stdoutBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+
+	err = executor.Run(cmd)
+	stdout := strings.TrimSpace(stdoutBuf.String())
+	stderr := strings.TrimSpace(stderrBuf.String())
+
+	if err != nil {
+		return "", fmt.Errorf("exec jq: \nerr: '%s'\nstderr: '%s'", err, stderr)
+	}
+
+	return stdout, nil
+}

--- a/pkg/jq/filter.go
+++ b/pkg/jq/filter.go
@@ -1,0 +1,9 @@
+package jq
+
+// ApplyJqFilter runs jq expression provided in jqFilter with jsonData as input.
+//
+// It uses libjq-go when CGO is enabled and executes jq binary
+// if CGO is disabled or JQ_EXEC variable is set to "yes".
+func ApplyJqFilter(jqFilter string, jsonData []byte, libPath string) (string, error) {
+	return runJqFilter(jqFilter, jsonData, libPath)
+}

--- a/pkg/jq/nocgo_filter.go
+++ b/pkg/jq/nocgo_filter.go
@@ -1,0 +1,8 @@
+// +build !cgo
+
+package jq
+
+// runJqFilter runs exec filter if CGO is disabled.
+func runJqFilter(jqFilter string, jsonData []byte, libPath string) (result string, err error) {
+	return jqFilterExec(jqFilter, jsonData, libPath)
+}

--- a/pkg/kube_events_manager/filter.go
+++ b/pkg/kube_events_manager/filter.go
@@ -1,0 +1,62 @@
+package kube_events_manager
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"runtime/trace"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/flant/shell-operator/pkg/app"
+	"github.com/flant/shell-operator/pkg/jq"
+	utils_checksum "github.com/flant/shell-operator/pkg/utils/checksum"
+
+	. "github.com/flant/shell-operator/pkg/kube_events_manager/types"
+)
+
+// ApplyFilter filters object json representation with jq expression, calculate checksum
+// over result and return ObjectAndFilterResult. If jqFilter is empty, no filter
+// is required and checksum is calculated over full json representation of the object.
+func ApplyFilter(jqFilter string, filterFn func(obj *unstructured.Unstructured) (result string, err error), obj *unstructured.Unstructured) (*ObjectAndFilterResult, error) {
+	defer trace.StartRegion(context.Background(), "ApplyJqFilter").End()
+
+	res := &ObjectAndFilterResult{
+		Object: obj,
+	}
+	res.Metadata.JqFilter = jqFilter
+	res.Metadata.ResourceId = ResourceId(obj)
+
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+	res.ObjectBytes = int64(len(data))
+
+	// If filterFn is passed, run it and return result.
+	if filterFn != nil {
+		var err error
+		var filtered string
+		filtered, err = filterFn(obj)
+		if err != nil {
+			return nil, fmt.Errorf("filterFn: %v", err)
+		}
+		res.FilterResult = filtered
+		res.Metadata.Checksum = utils_checksum.CalculateChecksum(filtered)
+		return res, nil
+	}
+
+	if jqFilter == "" {
+		res.Metadata.Checksum = utils_checksum.CalculateChecksum(string(data))
+	} else {
+		var err error
+		var filtered string
+		filtered, err = jq.ApplyJqFilter(jqFilter, data, app.JqLibraryPath)
+		if err != nil {
+			return nil, fmt.Errorf("jqFilter: %v", err)
+		}
+		res.FilterResult = filtered
+		res.Metadata.Checksum = utils_checksum.CalculateChecksum(filtered)
+	}
+	return res, nil
+}

--- a/pkg/kube_events_manager/resource_informer.go
+++ b/pkg/kube_events_manager/resource_informer.go
@@ -209,7 +209,7 @@ func (ei *resourceInformer) LoadExistedObjects() error {
 			defer measure.Duration(func(d time.Duration) {
 				ei.metricStorage.HistogramObserve("{PREFIX}kube_jq_filter_duration_seconds", d.Seconds(), ei.Monitor.Metadata.MetricLabels)
 			})()
-			objFilterRes, err = ApplyJqFilter(ei.Monitor.JqFilter, ei.Monitor.FilterFunc, &obj)
+			objFilterRes, err = ApplyFilter(ei.Monitor.JqFilter, ei.Monitor.FilterFunc, &obj)
 		}()
 
 		if err != nil {
@@ -283,7 +283,7 @@ func (ei *resourceInformer) HandleWatchEvent(object interface{}, eventType Watch
 		defer measure.Duration(func(d time.Duration) {
 			ei.metricStorage.HistogramObserve("{PREFIX}kube_jq_filter_duration_seconds", d.Seconds(), ei.Monitor.Metadata.MetricLabels)
 		})()
-		objFilterRes, err = ApplyJqFilter(ei.Monitor.JqFilter, ei.Monitor.FilterFunc, obj)
+		objFilterRes, err = ApplyFilter(ei.Monitor.JqFilter, ei.Monitor.FilterFunc, obj)
 	}()
 	if err != nil {
 		log.Errorf("%s: WATCH %s: %s",

--- a/pkg/kube_events_manager/util.go
+++ b/pkg/kube_events_manager/util.go
@@ -1,111 +1,16 @@
 package kube_events_manager
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
 	"fmt"
 	"math/rand"
-	"os"
-	"os/exec"
-	"runtime/trace"
-	"strings"
 	"time"
 
-	. "github.com/flant/libjq-go"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/fields"
 
 	. "github.com/flant/shell-operator/pkg/kube_events_manager/types"
-
-	"github.com/flant/shell-operator/pkg/app"
-	"github.com/flant/shell-operator/pkg/executor"
-	utils_checksum "github.com/flant/shell-operator/pkg/utils/checksum"
 )
-
-// ApplyJqFilter filter object json representation with jq expression, calculate checksum
-// over result and return ObjectAndFilterResult. If jqFilter is empty, no filter
-// is required and checksum is calculated over full json representation of the object.
-func ApplyJqFilter(jqFilter string, filterFn func(obj *unstructured.Unstructured) (result string, err error), obj *unstructured.Unstructured) (*ObjectAndFilterResult, error) {
-	defer trace.StartRegion(context.Background(), "ApplyJqFilter").End()
-
-	res := &ObjectAndFilterResult{
-		Object: obj,
-	}
-	res.Metadata.JqFilter = jqFilter
-	res.Metadata.ResourceId = ResourceId(obj)
-
-	data, err := json.Marshal(obj)
-	if err != nil {
-		return nil, err
-	}
-	res.ObjectBytes = int64(len(data))
-
-	// If filterFn is passed, run it and return result.
-	if filterFn != nil {
-		var err error
-		var filtered string
-		filtered, err = filterFn(obj)
-		if err != nil {
-			return nil, fmt.Errorf("filterFn: %v", err)
-		}
-		res.FilterResult = filtered
-		res.Metadata.Checksum = utils_checksum.CalculateChecksum(filtered)
-		return res, nil
-	}
-
-	if jqFilter == "" {
-		res.Metadata.Checksum = utils_checksum.CalculateChecksum(string(data))
-	} else {
-		var err error
-		var filtered string
-		if os.Getenv("JQ_EXEC") == "yes" {
-			stdout, stderr, err := execJq(jqFilter, data)
-			if err != nil {
-				return nil, fmt.Errorf("failed exec jq: \nerr: '%s'\nstderr: '%s'", err, stderr)
-			}
-
-			filtered = stdout
-		} else {
-			filtered, err = Jq().WithLibPath(app.JqLibraryPath).Program(jqFilter).Cached().Run(string(data))
-			if err != nil {
-				return nil, fmt.Errorf("failed jq filter '%s': '%s'", jqFilter, err)
-			}
-		}
-		res.FilterResult = filtered
-		res.Metadata.Checksum = utils_checksum.CalculateChecksum(filtered)
-	}
-	return res, nil
-}
-
-// TODO: Can be removed after testing with libjq-go
-// execJq run jq in locked mode with executor
-func execJq(jqFilter string, jsonData []byte) (stdout string, stderr string, err error) {
-	var cmd *exec.Cmd
-	if app.JqLibraryPath == "" {
-		cmd = exec.Command("/usr/bin/jq", jqFilter)
-	} else {
-		cmd = exec.Command("/usr/bin/jq", "-L", app.JqLibraryPath, jqFilter)
-	}
-
-	var stdinBuf bytes.Buffer
-	_, err = stdinBuf.WriteString(string(jsonData))
-	if err != nil {
-		panic(err)
-	}
-	cmd.Stdin = &stdinBuf
-	var stdoutBuf bytes.Buffer
-	cmd.Stdout = &stdoutBuf
-	var stderrBuf bytes.Buffer
-	cmd.Stderr = &stderrBuf
-
-	err = executor.Run(cmd)
-	stdout = strings.TrimSpace(stdoutBuf.String())
-	stderr = strings.TrimSpace(stderrBuf.String())
-
-	return
-}
 
 // ResourceId describes object with namespace, kind and name
 //


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

flant/libjq-go is required only if cgo is enabled.

#### What this PR does / why we need it

Build with CGO_ENABLED=0 is not require libjq-go anymore, so it is possible to use various parts of the shell-operator in projects that don't require jqFilter. For example, Kubernetes client in `pkg/kube` or Prometheus client in `pkg/metric_storage` or Monitors with custom FilterFunc in `pkg/kube_events_manager`.

`JQ_EXEC=yes` environment variable still can be used to force `/usr/bin/jq` execution if the shell-operator is built with cgo enabled.

#### Special notes for your reviewer



#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```