### PR TITLE
fix: add UpdateSnapshots in generator.go

### DIFF
--- a/test/hook/context/generator.go
+++ b/test/hook/context/generator.go
@@ -193,6 +193,7 @@ func (b *BindingContextController) ChangeStateAndWaitForBindingContexts(desiredQ
 		}
 	}
 
+	bindingContexts = b.HookCtrl.UpdateSnapshots(bindingContexts)
 	return convertBindingContexts(bindingContexts)
 }
 


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Call UpdateSnapshots in `generator.go` to get snapshots in hook tests.
<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

`HookCtrl.HandleKubeEvent` method does not return snapshots anymore to use less memory for queued tasks.

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```