### PR TITLE
frameworks and shell-operator already in base image

### DIFF
--- a/examples/204-validating-webhook/Dockerfile
+++ b/examples/204-validating-webhook/Dockerfile
@@ -1,9 +1,5 @@
 FROM flant/shell-operator:latest
 LABEL app="shell-operator" example="204-validating-webhook"
 
-ADD frameworks/shell /frameworks/shell
 # Add hooks
 ADD hooks /hooks
-
-# Compiled version of shell-operator binary
-ADD shell-operator /


### PR DESCRIPTION
#### Overview
Do not add files from context that are already present in base image `flant/shell-operator:latest`.

#### What this PR does / why we need it
Currently the build fails with:
```
Step 3/5 : ADD frameworks/shell /frameworks/shell
ADD failed: file not found in build context or excluded by .dockerignore: stat frameworks/shell: file does not exist
```

#### Does this PR introduce a user-facing change?
No.