### PR TITLE
feat: execution rate settings for hook

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -51,6 +51,8 @@ kubernetes:
 kubernetesValidating:
 - {VALIDATING_PARAMETERS}
 - {VALIDATING_PARAMETERS}
+settings:
+  SETTINGS_PARAMETERS
 ```
 
 or in JSON format:
@@ -70,7 +72,8 @@ or in JSON format:
   "kubernetesValidating": [
     {VALIDATING_PARAMETERS},
     {VALIDATING_PARAMETERS}
-  ]
+  ],
+  "settings": {SETTINGS_PARAMETERS}
 }
 ```
 
@@ -403,7 +406,7 @@ kubernetes:
 
 During startup, the hook receives all existing objects with "Synchronization"-type binding context:
 
-```json
+```yaml
 [
   {
     "binding": "kubernetes",
@@ -422,9 +425,9 @@ During startup, the hook receives all existing objects with "Synchronization"-ty
       {
         "object": {
           "kind": "Pod",
-          "metadata":{
-            "name":"kube-proxy-...",
-            "namespace":"kube-system",
+          "metadata": {
+            "name": "kube-proxy-...",
+            "namespace": "kube-system",
             ...
           },
         }
@@ -439,7 +442,7 @@ During startup, the hook receives all existing objects with "Synchronization"-ty
 
 If pod `pod-321d12` is then added into namespace 'default', then the hook will be executed with the "Event"-type binding context:
 
-```json
+```yaml
 [
   {
     "binding": "kubernetes",
@@ -470,15 +473,15 @@ Snapshot is a list of cached kubernetes objects and corresponding jqFilter resul
 
 `snapshots` format:
 
-```json
+```yaml
     "snapshots": {
       "binding-name-1": [ 
         {
           "object": {
             "kind": "Pod",
-            "metadata":{
-              "name":"etcd-...",
-              "namespace":"kube-system",
+            "metadata": {
+              "name": "etcd-...",
+              "namespace": "kube-system",
               ...
             },
           },
@@ -498,7 +501,7 @@ Note that disabling full objects make sense only if `jqFilter` is defined, as it
 
 For example, this binding configuration will execute hook with empty items in `objects` field of "Synchronization" binding context:
  
-```
+```yaml
 kubernetes:
 - name: pods
   kinds: Pod   
@@ -522,20 +525,20 @@ kubernetes:
 
 #### "Synchronization" binding context with snapshots
 
-During startup, the hook will be executed with the "Synchronization" binding context with `snapshots` JSON object:
+During startup, the hook will be executed with the "Synchronization" binding context with `snapshots` and `objects`:
 
-```json
+```yaml
 [
   {
-    "binding": "kubernetes",
+    "binding": "monitor-pods",
     "type": "Synchronization",
     "objects": [
       {
         "object": {
           "kind": "Pod",
-          "metadata":{
-            "name":"etcd-...",
-            "namespace":"kube-system",
+          "metadata": {
+            "name": "etcd-...",
+            "namespace": "kube-system",
             "labels": { ... },
             ...
           },
@@ -548,9 +551,9 @@ During startup, the hook will be executed with the "Synchronization" binding con
       {
         "object": {
           "kind": "Pod",
-          "metadata":{
-            "name":"kube-proxy-...",
-            "namespace":"kube-system",
+          "metadata": {
+            "name": "kube-proxy-...",
+            "namespace": "kube-system",
             ...
           },
         },
@@ -566,9 +569,9 @@ During startup, the hook will be executed with the "Synchronization" binding con
         {
           "object": {
             "kind": "Pod",
-            "metadata":{
-              "name":"etcd-...",
-              "namespace":"kube-system",
+            "metadata": {
+              "name": "etcd-...",
+              "namespace": "kube-system",
               ...
             },
           },
@@ -585,10 +588,10 @@ During startup, the hook will be executed with the "Synchronization" binding con
 
 If pod `pod-321d12` is then added into the "default" namespace, then the hook will be executed with the "Event" binding context with `object` and `filterResult` fields:
 
-```json
+```yaml
 [
   {
-    "binding": "kubernetes",
+    "binding": "monitor-pods",
     "type": "Event",
     "watchEvent": "Added",
     "object": {
@@ -610,9 +613,9 @@ If pod `pod-321d12` is then added into the "default" namespace, then the hook wi
         {
           "object": {
             "kind": "Pod",
-            "metadata":{
-              "name":"etcd-...",
-              "namespace":"kube-system",
+            "metadata": {
+              "name": "etcd-...",
+              "namespace": "kube-system",
               ...
             },
           },
@@ -629,7 +632,7 @@ If pod `pod-321d12` is then added into the "default" namespace, then the hook wi
 
 at 12:02, the hook will be executed with the following binding context:
 
-```json
+```yaml
 [
   {
     "binding": "incremental",
@@ -639,9 +642,9 @@ at 12:02, the hook will be executed with the following binding context:
         {
           "object": {
             "kind": "Pod",
-            "metadata":{
-              "name":"etcd-...",
-              "namespace":"kube-system",
+            "metadata": {
+              "name": "etcd-...",
+              "namespace": "kube-system",
               ...
             },
           },
@@ -692,7 +695,7 @@ kubernetes:
 
 During startup, the hook will be executed with the "Synchronization" binding context with `snapshots` JSON object:
 
-```json
+```yaml
 [
   {
     "binding": "pods",
@@ -702,9 +705,9 @@ During startup, the hook will be executed with the "Synchronization" binding con
         {
           "object": {
             "kind": "Pod",
-            "metadata":{
-              "name":"etcd-...",
-              "namespace":"kube-system",
+            "metadata": {
+              "name": "etcd-...",
+              "namespace": "kube-system",
               ...
             },
           },
@@ -716,9 +719,9 @@ During startup, the hook will be executed with the "Synchronization" binding con
         {
           "object": {
             "kind": "ConfigMap",
-            "metadata":{
-              "name":"etcd-...",
-              "namespace":"kube-system",
+            "metadata": {
+              "name": "etcd-...",
+              "namespace": "kube-system",
               ...
             },
           },
@@ -735,7 +738,7 @@ During startup, the hook will be executed with the "Synchronization" binding con
 
 If pod `pod-dfbd12` is then added into the "default" namespace, then the hook will be executed with the "Group" binding context:
 
-```json
+```yaml
 [
   {
     "binding": "pods",
@@ -776,7 +779,7 @@ If pod `pod-dfbd12` is then added into the "default" namespace, then the hook wi
 
 Every minute it will be executed with the same binding context with fresh snapshots:
 
-```json
+```yaml
 [
   {
     "binding": "pods",
@@ -792,3 +795,43 @@ Every minute it will be executed with the same binding context with fresh snapsh
   }
 ]
 ```
+
+### settings
+
+An optional block with hook-level settings.
+
+#### Syntax
+
+```yaml
+configVersion: v1
+settings:
+  executionMinPeriod: 3s
+  executionBurst: 1
+```
+
+#### Parameters
+
+- `executionMinPeriod` defines a minimum time between hook executions.
+- `executionBurst` a number of allowed executions during a period.
+
+#### Execution rate
+
+`executionMinPeriod` and `executionBurst` are parameters for "token bucket" algorithm. These parameters are used to throttle hook executions and wait for more events in the queue. It is wise to use a separate queue for bindings in such a hook, as a hook with execution rate settings and with default ("main") queue can hold the execution of other hooks.
+
+#### Example
+
+```yaml
+configVersion: v1
+kubernetes:
+- name: "all-pods-in-ns"
+  kind: pod
+  executeHookOnEvent: ["Modified"]
+  namespace:
+    nameSelector: ["default"]
+  queue: handle-pods-queue
+settings:
+  executionMinPeriod: 3s
+  executionBurst: 1
+```
+
+Hook with these settings will be executed once in 3 seconds.

--- a/examples/220-execution-rate/.dockerignore
+++ b/examples/220-execution-rate/.dockerignore
@@ -1,0 +1,6 @@
+templates
+.helmignore
+Chart.yaml
+crontab*.yaml
+README.md
+values.yaml

--- a/examples/220-execution-rate/.helmignore
+++ b/examples/220-execution-rate/.helmignore
@@ -1,0 +1,4 @@
+crontab-recreate.sh
+Dockerfile
+README.md
+shell-operator

--- a/examples/220-execution-rate/Chart.yaml
+++ b/examples/220-execution-rate/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+name: 210-conversion-webhook
+version: 1.0.0
+description: Shell-operator CRD conversion hook example

--- a/examples/220-execution-rate/Dockerfile
+++ b/examples/220-execution-rate/Dockerfile
@@ -1,0 +1,5 @@
+FROM flant/shell-operator:latest
+LABEL app="shell-operator" example="220-execution-rate"
+
+# Add hooks
+ADD hooks /hooks

--- a/examples/220-execution-rate/README.md
+++ b/examples/220-execution-rate/README.md
@@ -1,0 +1,64 @@
+# Example with conversion hooks
+
+This is a simple example of execution rate settings. Read more information in [HOOKS.md](../../HOOKS.md#execution-rate).
+
+The example contains one hook that is subscribed to "crontab" resources and should be executed not more than once in 5 seconds.
+
+## Run
+
+### Build and install example
+
+Build Docker image and use helm3 to install it:
+
+```
+docker build -t localhost:5000/shell-operator:example-220 .
+docker push localhost:5000/shell-operator:example-220
+helm upgrade --install \
+    --namespace example-220 \
+    --create-namespace \
+    example-220 .
+```
+
+### See rate limited hook in action
+
+1. Run a simple script to recreate "crontab" resources and thus emit multiple events:
+
+```
+$ ./crontab-recreate.sh
+crontab.stable.example.com "crontab-obj-1" deleted
+crontab.stable.example.com/crontab-obj-1 replaced
+crontab.stable.example.com "crontab-obj-2" deleted
+crontab.stable.example.com/crontab-obj-2 replaced
+crontab.stable.example.com "crontab-obj-3" deleted
+crontab.stable.example.com/crontab-obj-3 replaced
+crontab.stable.example.com "crontab-obj-4" deleted
+crontab.stable.example.com/crontab-obj-4 replaced
+crontab.stable.example.com "crontab-obj-1" deleted
+crontab.stable.example.com/crontab-obj-1 replaced
+crontab.stable.example.com "crontab-obj-2" deleted
+crontab.stable.example.com/crontab-obj-2 replaced
+...
+```
+
+2. Now see what's in logs:
+
+```
+$ kubectl -n example-220 logs deploy/shell-operator -f | grep RateLimitedHook
+
+{"binding":"crontabs","event":"kubernetes","hook":"settings-rate-limit.sh","level":"info","msg":"RateLimitedHook binding contexts: 18","output":"stdout","queue":"main","task":"HookRun","time":"2021-02-27T12:57:42Z"}
+{"binding":"crontabs","event":"kubernetes","hook":"settings-rate-limit.sh","level":"info","msg":"RateLimitedHook binding contexts: 24","output":"stdout","queue":"main","task":"HookRun","time":"2021-02-27T12:57:47Z"}
+{"binding":"crontabs","event":"kubernetes","hook":"settings-rate-limit.sh","level":"info","msg":"RateLimitedHook binding contexts: 24","output":"stdout","queue":"main","task":"HookRun","time":"2021-02-27T12:57:52Z"}
+{"binding":"crontabs","event":"kubernetes","hook":"settings-rate-limit.sh","level":"info","msg":"RateLimitedHook binding contexts: 16","output":"stdout","queue":"main","task":"HookRun","time":"2021-02-27T12:57:57Z"}
+{"binding":"crontabs","event":"kubernetes","hook":"settings-rate-limit.sh","level":"info","msg":"RateLimitedHook binding contexts: 24","output":"stdout","queue":"main","task":"HookRun","time":"2021-02-27T12:58:02Z"}
+{"binding":"crontabs","event":"kubernetes","hook":"settings-rate-limit.sh","level":"info","msg":"RateLimitedHook binding contexts: 24","output":"stdout","queue":"main","task":"HookRun","time":"2021-02-27T12:58:07Z"}
+```
+
+Note that hook is executed every 5s as stated in its settings.
+
+### Cleanup
+
+```
+helm delete --namespace=example-220 example-220
+kubectl delete ns example-220
+kubectl delete crd crontabs.stable.example.com
+```

--- a/examples/220-execution-rate/crontab-recreate.sh
+++ b/examples/220-execution-rate/crontab-recreate.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+while true ; do
+  for i in `seq 1 4` ; do
+     (cat <<EOF | kubectl -n example-220 replace --force -f - ; true
+apiVersion: "stable.example.com/v1"
+kind: CronTab
+metadata:
+  name: crontab-obj-${i}
+  labels:
+    foo: bar
+spec:
+  cron: "= = = = =/10"
+  image: some-cron-image-${i}
+EOF
+)
+  done
+  sleep 1
+done

--- a/examples/220-execution-rate/hooks/settings-rate-limit.sh
+++ b/examples/220-execution-rate/hooks/settings-rate-limit.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+if [[ $1 == "--config" ]] ; then
+  cat <<EOF
+configVersion: v1
+settings:
+  executionMinInterval: 5s
+  executionBurst: 2
+kubernetes:
+- name: crontabs
+  apiVersion: stable.example.com/v1
+  kind: ct
+EOF
+exit 0
+fi
+
+
+echo "settings-rate-limit on kube"
+
+CONTEXT_LENGTH=$(jq -r '.|length' ${BINDING_CONTEXT_PATH})
+echo "RateLimitedHook binding contexts: ${CONTEXT_LENGTH}"

--- a/examples/220-execution-rate/templates/crd/crontab.yaml
+++ b/examples/220-execution-rate/templates/crd/crontab.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: crontabs.stable.example.com
+  labels:
+    heritage: example-220
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: stable.example.com
+  # list of versions supported by this CustomResourceDefinition
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required: [cron, imageName]
+              properties:
+                cron:
+                  type: array
+                  items:
+                    type: string
+                imageName:
+                  type: string
+    - name: v1alpha2
+      served: true
+      storage: false
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required: [cron, imageName]
+              properties:
+                cron:
+                  type: string
+                imageName:
+                  type: string
+
+  # either Namespaced or Cluster
+  scope: Namespaced
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: crontabs
+    # singular name to be used as an alias on the CLI and for display
+    singular: crontab
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: CronTab
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+      - ct

--- a/examples/220-execution-rate/templates/deployment.yaml
+++ b/examples/220-execution-rate/templates/deployment.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: shell-operator
+  labels:
+    heritage: example-220
+    app: shell-operator-example-220
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: shell-operator-example-220
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        heritage: example-220
+        app: shell-operator-example-220
+      annotations:
+        checksum/hook: {{ .Files.Get "hooks/settings-rate-limit.sh" | sha256sum }}
+    spec:
+      containers:
+      - name: shell-operator
+        image: {{ .Values.shellOperator.image | quote }}
+        imagePullPolicy: Always
+        env:
+        - name: SHELL_OPERATOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+      serviceAccountName: example-220-acc

--- a/examples/220-execution-rate/templates/rbac.yaml
+++ b/examples/220-execution-rate/templates/rbac.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: example-220-acc
+  labels:
+    heritage: example-220
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: example-220
+  labels:
+    heritage: example-220
+rules:
+- apiGroups: ["stable.example.com"]
+  resources: ["crontabs"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: example-220
+  labels:
+    heritage: example-220
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: example-220
+subjects:
+  - kind: ServiceAccount
+    name: example-220-acc
+    namespace: {{ .Release.Namespace }}

--- a/examples/220-execution-rate/values.yaml
+++ b/examples/220-execution-rate/values.yaml
@@ -1,0 +1,2 @@
+shellOperator:
+  image: localhost:5000/shell-operator:example-220

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/prometheus/client_golang v1.0.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.4.0
+	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/robfig/cron.v2 v2.0.0-20150107220207-be2e0b0deed5
 	gopkg.in/satori/go.uuid.v1 v1.2.0

--- a/pkg/hook/config/config.go
+++ b/pkg/hook/config/config.go
@@ -23,6 +23,7 @@ type HookConfig struct {
 	OnKubernetesEvents   []OnKubernetesEventConfig
 	KubernetesValidating []ValidatingConfig
 	KubernetesConversion []ConversionConfig
+	Settings             *Settings
 }
 
 // LoadAndValidate loads config from bytes and validate it. Returns multierror.

--- a/pkg/hook/config/config_test.go
+++ b/pkg/hook/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 
@@ -724,6 +725,36 @@ kubernetesCustomResourceConversion:
   conversions:
   - fromVersion: q
     to: q
+`,
+			func() {
+				g.Expect(err).Should(HaveOccurred())
+			},
+		},
+		{
+			"v1 settings",
+			`
+configVersion: v1
+settings:
+  executionMinInterval: 30s
+  executionBurst: 1
+`,
+			func() {
+				g.Expect(err).ShouldNot(HaveOccurred())
+				g.Expect(hookConfig.Version).To(Equal("v1"))
+				g.Expect(hookConfig.V0).To(BeNil())
+				g.Expect(hookConfig.V1).NotTo(BeNil())
+				g.Expect(hookConfig.Settings).NotTo(BeNil())
+				g.Expect(hookConfig.Settings.ExecutionMinInterval).To(Equal(time.Duration(time.Second * 30)))
+				g.Expect(hookConfig.Settings.ExecutionBurst).To(Equal(1))
+			},
+		},
+		{
+			"v1 settings with error",
+			`
+configVersion: v1
+settings:
+  executionMinInterval: 30ks
+  executionBurst: 1
 `,
 			func() {
 				g.Expect(err).Should(HaveOccurred())

--- a/pkg/hook/config/schemas.go
+++ b/pkg/hook/config/schemas.go
@@ -65,6 +65,14 @@ properties:
     type: string
     enum:
     - v1
+  settings:
+    type: object
+    additionalProperties: false
+    properties:
+      executionMinInterval:
+        type: string
+      executionBurst:
+        type: integer
   onStartup:
     title: onStartup binding
     description: |

--- a/pkg/hook/types/bindings.go
+++ b/pkg/hook/types/bindings.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"time"
+
 	"github.com/flant/shell-operator/pkg/kube_events_manager"
 	. "github.com/flant/shell-operator/pkg/schedule_manager/types"
 	"github.com/flant/shell-operator/pkg/webhook/conversion"
@@ -59,4 +61,9 @@ type ValidatingConfig struct {
 	IncludeSnapshotsFrom []string
 	Group                string
 	Webhook              *validating.ValidatingWebhookConfig
+}
+
+type Settings struct {
+	ExecutionMinInterval time.Duration
+	ExecutionBurst       int
 }

--- a/pkg/task/queue/task_queue.go
+++ b/pkg/task/queue/task_queue.go
@@ -28,7 +28,7 @@ config parameter.
 */
 
 var (
-	DelayOnQueueIsEmpty = 3 * time.Second
+	DelayOnQueueIsEmpty = 250 * time.Millisecond
 	DelayOnFailedTask   = 5 * time.Second
 	DelayOnRepeat       = 25 * time.Millisecond
 )


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Introduce settings to set execution rate for a hook.

#### What this PR does / why we need it

Shell-operator can combine tasks in the queue and run the hook once with an array of binding contexts. Execution rate settings help to handle multiple events that are occurred during a short period.

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

Yes, the new section "settings" is added to the configuration.

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```