### PR TITLE
fix: fresh objects for Synchronization executions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -88,7 +88,6 @@ jobs:
         run: |
           go build ./cmd/shell-operator
 
-
 # MacOS build works fine because jq package already has static libraries.
 # Windows build requires jq compilation, this should be done in libjq-go.
 # TODO Does cross-compile can help here?

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -279,9 +279,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest]
-        k8s_version: [1.16, 1.17]
-    runs-on: ${{ matrix.os }}
+        k8s_version: [1.16, 1.19, 1.20]
+    runs-on: ubuntu-latest
     env:
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:

--- a/pkg/hook/binding_context/binding_context.go
+++ b/pkg/hook/binding_context/binding_context.go
@@ -34,6 +34,10 @@ type BindingContext struct {
 	ToVersion        string
 }
 
+func (bc BindingContext) IsSynchronization() bool {
+	return bc.Metadata.BindingType == OnKubernetesEvent && bc.Type == TypeSynchronization
+}
+
 func (bc BindingContext) MarshalJSON() ([]byte, error) {
 	return json.Marshal(bc.Map())
 }
@@ -58,6 +62,7 @@ func (bc BindingContext) MapV1() map[string]interface{} {
 		return res
 	}
 
+	// Set "snapshots" field if needed.
 	if len(bc.Metadata.IncludeSnapshots) > 0 || bc.Metadata.IncludeAllSnapshots {
 		if len(bc.Snapshots) > 0 {
 			res["snapshots"] = bc.Snapshots
@@ -66,6 +71,7 @@ func (bc BindingContext) MapV1() map[string]interface{} {
 		}
 	}
 
+	// Handle validating and conversion before grouping.
 	if bc.Metadata.BindingType == KubernetesValidating {
 		res["type"] = "Validating"
 		res["review"] = bc.AdmissionReview
@@ -80,8 +86,8 @@ func (bc BindingContext) MapV1() map[string]interface{} {
 		return res
 	}
 
-	// KubernetesValidating uses 'group' only for snapshots.
-	if bc.Metadata.Group != "" && bc.Metadata.BindingType != KubernetesValidating {
+	// Group is always has "type: Group", even for Synchronization.
+	if bc.Metadata.Group != "" {
 		res["binding"] = bc.Metadata.Group
 		res["type"] = "Group"
 		return res

--- a/pkg/kube_events_manager/kube_events_manager_test.go
+++ b/pkg/kube_events_manager/kube_events_manager_test.go
@@ -67,7 +67,7 @@ func Test_MainKubeEventsManager_Run(t *testing.T) {
 
 	monitor.Metadata.MonitorId = "MonitorId"
 
-	_, err := mgr.AddMonitor(monitor)
+	err := mgr.AddMonitor(monitor)
 
 	if assert.NoError(t, err) {
 		assert.Len(t, mgr.Monitors, 1)
@@ -155,14 +155,10 @@ func Test_MainKubeEventsManager_HandleEvents(t *testing.T) {
 	}
 	monitor.Metadata.MonitorId = "MonitorId"
 
-	_, err := mgr.AddMonitor(monitor)
+	err := mgr.AddMonitor(monitor)
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
-
-	mgr.Start()
-
-	fmt.Printf("mgr Started\n")
 
 	// First event — Synchronization, second and third are Event
 	eventCounter := 0
@@ -336,14 +332,10 @@ func Test_FakeClient_CatchUpdates(t *testing.T) {
 	}
 	monitor.Metadata.MonitorId = "MonitorId"
 
-	_, err := mgr.AddMonitor(monitor)
+	err := mgr.AddMonitor(monitor)
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
-
-	mgr.Start()
-
-	fmt.Printf("mgr Started\n")
 
 	// First event — Synchronization, second and third are Event
 	eventCounter := 0

--- a/pkg/shell-operator/operator_test.go
+++ b/pkg/shell-operator/operator_test.go
@@ -99,10 +99,11 @@ func Test_CombineBindingContext_MultipleHooks(t *testing.T) {
 	}
 	g.Expect(op.TaskQueues.GetByName("test_multiple_hooks").Length()).Should(Equal(len(tasks)))
 
-	bcs := op.CombineBindingContextForHook(op.TaskQueues.GetByName("test_multiple_hooks"), tasks[0], nil)
+	combineResult := op.CombineBindingContextForHook(op.TaskQueues.GetByName("test_multiple_hooks"), tasks[0], nil)
 
 	// Should combine binding contexts from 4 tasks.
-	g.Expect(bcs).Should(HaveLen(4))
+	g.Expect(combineResult).ShouldNot(BeNil())
+	g.Expect(combineResult.BindingContexts).Should(HaveLen(4))
 	// Should delete 3 tasks
 	g.Expect(op.TaskQueues.GetByName("test_multiple_hooks").Length()).Should(Equal(len(tasks) - 3))
 }
@@ -159,9 +160,9 @@ func Test_CombineBindingContext_Nil_On_NoCombine(t *testing.T) {
 	}
 	g.Expect(op.TaskQueues.GetByName("test_no_combine").Length()).Should(Equal(len(tasks)))
 
-	bcs := op.CombineBindingContextForHook(op.TaskQueues.GetByName("test_no_combine"), tasks[0], nil)
+	combineResult := op.CombineBindingContextForHook(op.TaskQueues.GetByName("test_no_combine"), tasks[0], nil)
 	// Should return nil if no combine
-	g.Expect(bcs).Should(BeNil())
+	g.Expect(combineResult).Should(BeNil())
 	// Should not delete tasks
 	g.Expect(op.TaskQueues.GetByName("test_no_combine").Length()).Should(Equal(len(tasks)))
 }
@@ -259,9 +260,10 @@ func Test_CombineBindingContext_Group_Compaction(t *testing.T) {
 	}
 	g.Expect(op.TaskQueues.GetByName("test_multiple_hooks").Length()).Should(Equal(len(tasks)))
 
-	bcList := op.CombineBindingContextForHook(op.TaskQueues.GetByName("test_multiple_hooks"), tasks[0], nil)
+	combineResult := op.CombineBindingContextForHook(op.TaskQueues.GetByName("test_multiple_hooks"), tasks[0], nil)
 	// Should compact 4 tasks into 4 binding context and combine 3 binding contexts into one.
-	g.Expect(bcList).Should(HaveLen(2))
+	g.Expect(combineResult).ShouldNot(BeNil())
+	g.Expect(combineResult.BindingContexts).Should(HaveLen(2))
 
 	// Should delete 3 tasks
 	g.Expect(op.TaskQueues.GetByName("test_multiple_hooks").Length()).Should(Equal(len(tasks) - 3))
@@ -408,9 +410,12 @@ func Test_CombineBindingContext_Group_Type(t *testing.T) {
 	}
 	g.Expect(op.TaskQueues.GetByName("test_multiple_hooks").Length()).Should(Equal(len(tasks)))
 
-	bcList := op.CombineBindingContextForHook(op.TaskQueues.GetByName("test_multiple_hooks"), tasks[0], nil)
+	combineResult := op.CombineBindingContextForHook(op.TaskQueues.GetByName("test_multiple_hooks"), tasks[0], nil)
 	// Should leave 3 tasks in queue.
+	g.Expect(combineResult).ShouldNot(BeNil())
 	g.Expect(op.TaskQueues.GetByName("test_multiple_hooks").Length()).Should(Equal(3))
+
+	bcList := combineResult.BindingContexts
 
 	// Should combine binding contexts from 7 tasks. Should compact 3 binding contexts into 1.
 	g.Expect(bcList).Should(HaveLen(5))

--- a/test/hook/context/generator.go
+++ b/test/hook/context/generator.go
@@ -135,7 +135,7 @@ func (b *BindingContextController) Run(initialState string) (GeneratedBindingCon
 		return GeneratedBindingContexts{}, fmt.Errorf("couldn't enable kubernetes bindings: %v", err)
 	}
 
-	b.HookCtrl.StartMonitors()
+	b.HookCtrl.UnlockKubernetesEvents()
 
 	<-time.After(time.Millisecond) // tick to trigger informers
 	bindingContexts = b.HookCtrl.UpdateSnapshots(bindingContexts)

--- a/test/utils/kind-k8s-cluster.go
+++ b/test/utils/kind-k8s-cluster.go
@@ -65,7 +65,6 @@ func KindCreateCluster(clusterName string) error {
 	}
 
 	return nil
-
 }
 
 func KindDeleteCluster(clusterName string) error {


### PR DESCRIPTION

<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Set `objects` in "Synchronization" binding context to an actual state in cluster.

<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

- snapshots in monitors are updated without Event tasks until success Synchronization execution
- fix documentation for "Group" binding context

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

Integration tests are fixed, but there are 3 clusters in use. We need to refactor this part in the future.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```