### PR TITLE
fix: add v1beta1 to conversion config to work with 1.16+

### DIFF
--- a/examples/210-conversion-webhook/.dockerignore
+++ b/examples/210-conversion-webhook/.dockerignore
@@ -2,5 +2,4 @@ templates
 .helmignore
 Chart.yaml
 crontab*.yaml
-README.md
 values.yaml

--- a/pkg/webhook/conversion/crd_client_config.go
+++ b/pkg/webhook/conversion/crd_client_config.go
@@ -20,7 +20,7 @@ type CrdClientConfig struct {
 	CABundle    []byte
 }
 
-var SupportedConversionReviewVersions = []string{"v1"}
+var SupportedConversionReviewVersions = []string{"v1", "v1beta1"}
 
 func (c *CrdClientConfig) Update() error {
 	client := c.KubeClient

--- a/pkg/webhook/conversion/handler.go
+++ b/pkg/webhook/conversion/handler.go
@@ -70,6 +70,7 @@ func (h *WebhookHandler) ServeReviewRequest(w http.ResponseWriter, r *http.Reque
 }
 
 // See https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#write-a-conversion-webhook-server
+// This code always response with v1 ConversionReview: it works for 1.16+.
 func (h *WebhookHandler) HandleReviewRequest(path string, body []byte) (*v1.ConversionReview, error) {
 	crdName := DetectCrdName(path)
 	log.Infof("Got ConversionReview request for crd/%s", crdName)


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Add v1beta1 to the `conversionReviewVersions` list.

#### What this PR does / why we need it

`v1` only in conversionReviewVersion leads to an error on Kubernetes 1.16:

```
{"level":"error","msg":"ConversionWebhookManager Start: CustomResourceDefinition.apiextensions.k8s.io \"crontabs.stable.example.com\" is invalid: spec.conversion.conversionReviewVersions: Invalid value: []string{\"v1\"}: must include at least one of v1beta1","time":"2021-05-04T11:17:45Z"}
```

Despite the alert "Conversion webhooks must respond with a ConversionReview object in the same apiVersion they receive.", Shell-operator returns v1.ConversionReview and it works well on 1.16+. Also, input ConversionReview is always v1 for 1.16+. So, just adding  "v1beta1" to the list is enough. 

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```