### PR TITLE
Add histogram support for custom (non-grouped) metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# IDE proj files
+.idea
+*.iml
+*.proj

--- a/METRICS.md
+++ b/METRICS.md
@@ -52,6 +52,12 @@ Operation to register a gauge and set its value:
 {"name":"metric_name","action":"set","value":33,"labels":{"label1":"value1"}}
 ```
 
+Operation to register a histogram and observe a duration (not yet supported for grouped metrics):
+
+```json
+{"name":"metric_name","action":"observe","value":42, "buckets": [1,2,5,10,20,50,100,200,500], "labels":{"label1":"value1"}}
+```
+
 Labels are not required, but Shell-operator adds a `hook` label with a path to a hook script relative to hooks directory.
 
 Several metrics can be exported at once. For example, this script will create 2 metrics:

--- a/METRICS.md
+++ b/METRICS.md
@@ -52,10 +52,10 @@ Operation to register a gauge and set its value:
 {"name":"metric_name","action":"set","value":33,"labels":{"label1":"value1"}}
 ```
 
-Operation to register a histogram and observe a duration (not yet supported for grouped metrics):
+Operation to register a histogram and observe a duration:
 
 ```json
-{"name":"metric_name","action":"observe","value":42, "buckets": [1,2,5,10,20,50,100,200,500], "labels":{"label1":"value1"}}
+{"name":"metric_name","action":"observe","value":42, "buckets": [1,2,5,10,20,50], "labels":{"label1":"value1"}}
 ```
 
 Labels are not required, but Shell-operator adds a `hook` label with a path to a hook script relative to hooks directory.
@@ -67,7 +67,7 @@ echo '{"name":"hook_metric_count","action":"add","value":1,"labels":{"label1":"v
 echo '{"name":"hook_metrics_items","action":"add","value":1,"labels":{"label1":"value1"}}' >> $METRICS_PATH
 ```
 
-The metric name is used as-is, so several hooks can export same metric name. It is responsibility of hooks‘ developer to maintain consistent label cardinality.
+The metric name is used as-is, so several hooks can export the same metric name. It is responsibility of hooks‘ developer to maintain consistent label cardinality.
 
 There are fields "add" and "set" that can be used as shortcuts for action and value. This feature may be deprecated in future releases.
 
@@ -93,6 +93,8 @@ To expire all metrics in a group, use action "expire":
 ```
 {"group":"group_name_1", "action":"expire"}
 ```
+
+**WARNING**: "observe" is currently an unsupported _action_ for grouped metrics
 
 ### Example
 

--- a/pkg/kube/metrics.go
+++ b/pkg/kube/metrics.go
@@ -21,9 +21,8 @@ import (
 type MetricStorage interface {
 	RegisterCounter(metric string, labels map[string]string) *prometheus.CounterVec
 	CounterAdd(metric string, value float64, labels map[string]string)
-	RegisterHistogram(metric string, labels map[string]string) *prometheus.HistogramVec
-	RegisterHistogramWithBuckets(metric string, labels map[string]string, buckets []float64) *prometheus.HistogramVec
-	HistogramObserve(metric string, value float64, labels map[string]string)
+	RegisterHistogram(metric string, labels map[string]string, buckets []float64) *prometheus.HistogramVec
+	HistogramObserve(metric string, value float64, labels map[string]string, buckets []float64)
 }
 
 // RegisterKubernetesClientMetrics defines metrics in Prometheus client.
@@ -35,7 +34,7 @@ func RegisterKubernetesClientMetrics(metricStorage MetricStorage, metricLabels m
 	labels["verb"] = ""
 	labels["url"] = ""
 
-	metricStorage.RegisterHistogramWithBuckets("{PREFIX}kubernetes_client_request_latency_seconds",
+	metricStorage.RegisterHistogram("{PREFIX}kubernetes_client_request_latency_seconds",
 		labels,
 		[]float64{
 			0.0,
@@ -47,7 +46,7 @@ func RegisterKubernetesClientMetrics(metricStorage MetricStorage, metricLabels m
 		})
 
 	// TODO update client-go to v.0.18.*
-	//metricStorage.RegisterHistogramWithBuckets("{PREFIX}kubernetes_client_rate_limiter_latency_seconds",
+	//metricStorage.RegisterHistogram("{PREFIX}kubernetes_client_rate_limiter_latency_seconds",
 	//	map[string]string{
 	//		"verb": "",
 	//		"url":  "",
@@ -93,27 +92,9 @@ func (c ClientRequestLatencyMetric) Observe(verb string, u url.URL, latency time
 		"{PREFIX}kubernetes_client_request_latency_seconds",
 		latency.Seconds(),
 		labels,
+		nil,
 	)
 }
-
-// RateLimiterLAtenct metric for versions v0.18.*
-//func NewRateLimiterLatencyMetric(metricStorage *metric_storage.MetricStorage) metrics.LatencyMetric {
-//	return ClientRateLimiterLatencyMetric{metricStorage}
-//}
-//
-//type ClientRateLimiterLatencyMetric struct {
-//	metricStorage *metric_storage.MetricStorage
-//}
-//
-//func (c ClientRateLimiterLatencyMetric) Observe(verb string, u url.URL, latency time.Duration) {
-//	c.metricStorage.HistogramObserve(
-//		"{PREFIX}kubernetes_client_rate_limiter_latency_seconds",
-//		latency.Seconds(),
-//		map[string]string{
-//			"verb": verb,
-//			"url":  u.String(),
-//		})
-//}
 
 func NewRequestResultMetric(metricStorage MetricStorage, labels map[string]string) metrics.ResultMetric {
 	return ClientRequestResultMetric{metricStorage, labels}

--- a/pkg/kube/metrics.go
+++ b/pkg/kube/metrics.go
@@ -43,7 +43,7 @@ func RegisterKubernetesClientMetrics(metricStorage MetricStorage, metricLabels m
 			0.01, 0.02, 0.05, // 10,20,50 milliseconds
 			0.1, 0.2, 0.5, // 100,200,500 milliseconds
 			1, 2, 5, // 1,2,5 seconds
-			10, // 10 seconds
+			10, 20, 50, // 10,20,50 seconds
 		})
 
 	// TODO update client-go to v.0.18.*

--- a/pkg/kube_events_manager/resource_informer.go
+++ b/pkg/kube_events_manager/resource_informer.go
@@ -239,7 +239,7 @@ func (ei *resourceInformer) LoadExistedObjects() error {
 		var err error
 		func() {
 			defer measure.Duration(func(d time.Duration) {
-				ei.metricStorage.HistogramObserve("{PREFIX}kube_jq_filter_duration_seconds", d.Seconds(), ei.Monitor.Metadata.MetricLabels)
+				ei.metricStorage.HistogramObserve("{PREFIX}kube_jq_filter_duration_seconds", d.Seconds(), ei.Monitor.Metadata.MetricLabels, nil)
 			})()
 			objFilterRes, err = ApplyFilter(ei.Monitor.JqFilter, ei.Monitor.FilterFunc, &obj)
 		}()
@@ -296,7 +296,7 @@ func (ei *resourceInformer) HandleWatchEvent(object interface{}, eventType Watch
 	}
 
 	defer measure.Duration(func(d time.Duration) {
-		ei.metricStorage.HistogramObserve("{PREFIX}kube_event_duration_seconds", d.Seconds(), ei.Monitor.Metadata.MetricLabels)
+		ei.metricStorage.HistogramObserve("{PREFIX}kube_event_duration_seconds", d.Seconds(), ei.Monitor.Metadata.MetricLabels, nil)
 	})()
 	defer trace.StartRegion(context.Background(), "HandleWatchEvent").End()
 
@@ -313,7 +313,7 @@ func (ei *resourceInformer) HandleWatchEvent(object interface{}, eventType Watch
 	var err error
 	func() {
 		defer measure.Duration(func(d time.Duration) {
-			ei.metricStorage.HistogramObserve("{PREFIX}kube_jq_filter_duration_seconds", d.Seconds(), ei.Monitor.Metadata.MetricLabels)
+			ei.metricStorage.HistogramObserve("{PREFIX}kube_jq_filter_duration_seconds", d.Seconds(), ei.Monitor.Metadata.MetricLabels, nil)
 		})()
 		objFilterRes, err = ApplyFilter(ei.Monitor.JqFilter, ei.Monitor.FilterFunc, obj)
 	}()

--- a/pkg/metric_storage/operation/operation.go
+++ b/pkg/metric_storage/operation/operation.go
@@ -115,7 +115,7 @@ func ValidateMetricOperation(op MetricOperation) error {
 	var opErrs *multierror.Error
 
 	if op.Action == "" {
-		opErrs = multierror.Append(opErrs, fmt.Errorf("one of: 'action', 'set', 'add' or 'observe' is required: %s", op))
+		opErrs = multierror.Append(opErrs, fmt.Errorf("one of: 'action', 'set' or 'add' is required: %s", op))
 	}
 
 	if op.Group == "" {

--- a/pkg/metric_storage/operation/operation.go
+++ b/pkg/metric_storage/operation/operation.go
@@ -144,6 +144,9 @@ func ValidateMetricOperation(op MetricOperation) error {
 	if op.Action == "observe" && op.Value == nil {
 		opErrs = multierror.Append(opErrs, fmt.Errorf("'value' is required for action 'observe': %s", op))
 	}
+	if op.Action == "observe" && op.Buckets == nil {
+		opErrs = multierror.Append(opErrs, fmt.Errorf("'buckets' is required for action 'observe': %s", op))
+	}
 
 	if op.Set != nil && op.Add != nil {
 		opErrs = multierror.Append(opErrs, fmt.Errorf("'set' and 'add' are mutual exclusive: %s", op))

--- a/pkg/metric_storage/vault/vault.go
+++ b/pkg/metric_storage/vault/vault.go
@@ -77,7 +77,7 @@ func (v *GroupedVault) CounterAdd(group string, name string, value float64, labe
 func (v *GroupedVault) GaugeSet(group string, name string, value float64, labels map[string]string) {
 	c, err := v.GetOrCreateGaugeCollector(name, LabelNames(labels))
 	if err != nil {
-		log.Errorf("CounterAdd: %v", err)
+		log.Errorf("GaugeSet: %v", err)
 		return
 	}
 	c.Set(group, value, labels)

--- a/pkg/shell-operator/metrics.go
+++ b/pkg/shell-operator/metrics.go
@@ -27,9 +27,10 @@ func RegisterTaskQueueMetrics(metricStorage *metric_storage.MetricStorage) {
 		[]float64{
 			0.0,
 			0.000001, 0.000002, 0.000005, // 1,2,5 microseconds
-			0.00001, 0.00002, 0.00005, // 10,20,50 microsends
+			0.00001, 0.00002, 0.00005, // 10,20,50 microseconds
 			0.0001, 0.0002, 0.0005, // 100, 200, 500 microseconds
 			0.001, 0.002, 0.005, // 1,2,5 milliseconds
+			0.01, 0.02, 0.05, // 10,20,50 milliseconds
 		},
 	)
 
@@ -52,7 +53,8 @@ func RegisterKubeEventsManagerMetrics(metricStorage *metric_storage.MetricStorag
 			0.01, 0.02, 0.05, // 10,20,50 milliseconds
 			0.1, 0.2, 0.5, // 100,200,500 milliseconds
 			1, 2, 5, // 1,2,5 seconds
-			10, // 10 seconds
+			10, 20, 50, // 10, 20, 50 seconds
+			100, 200, 500, // 100,200,500 seconds
 		},
 	)
 	// Duration of handling kubernetes event.
@@ -65,7 +67,8 @@ func RegisterKubeEventsManagerMetrics(metricStorage *metric_storage.MetricStorag
 			0.01, 0.02, 0.05, // 10,20,50 milliseconds
 			0.1, 0.2, 0.5, // 100,200,500 milliseconds
 			1, 2, 5, // 1,2,5 seconds
-			10, // 10 seconds
+			10, 20, 50, // 10, 20, 50 seconds
+			100, 200, 500, // 100,200,500 seconds
 		},
 	)
 }
@@ -93,7 +96,8 @@ func RegisterHookMetrics(metricStorage *metric_storage.MetricStorage) {
 			0.01, 0.02, 0.05, // 10,20,50 milliseconds
 			0.1, 0.2, 0.5, // 100,200,500 milliseconds
 			1, 2, 5, // 1,2,5 seconds
-			10, // 10 seconds
+			10, 20, 50, // 10,20,50 seconds
+			100, 200, 500, // 100,200,500 seconds
 		},
 	)
 
@@ -107,7 +111,8 @@ func RegisterHookMetrics(metricStorage *metric_storage.MetricStorage) {
 			0.01, 0.02, 0.05, // 10,20,50 milliseconds
 			0.1, 0.2, 0.5, // 100,200,500 milliseconds
 			1, 2, 5, // 1,2,5 seconds
-			10, // 10 seconds
+			10, 20, 50, // 10,20,50 seconds
+			100, 200, 500, // 100,200,500 seconds
 		},
 	)
 	// User CPU usage.
@@ -120,7 +125,8 @@ func RegisterHookMetrics(metricStorage *metric_storage.MetricStorage) {
 			0.01, 0.02, 0.05, // 10,20,50 milliseconds
 			0.1, 0.2, 0.5, // 100,200,500 milliseconds
 			1, 2, 5, // 1,2,5 seconds
-			10, // 10 seconds
+			10, 20, 50, // 10,20,50 seconds
+			100, 200, 500, // 100,200,500 seconds
 		},
 	)
 	// Max RSS in bytes.

--- a/pkg/shell-operator/metrics.go
+++ b/pkg/shell-operator/metrics.go
@@ -18,7 +18,7 @@ func RegisterCommonMetrics(metricStorage *metric_storage.MetricStorage) {
 }
 
 func RegisterTaskQueueMetrics(metricStorage *metric_storage.MetricStorage) {
-	metricStorage.RegisterHistogramWithBuckets(
+	metricStorage.RegisterHistogram(
 		"{PREFIX}tasks_queue_action_duration_seconds",
 		map[string]string{
 			"queue_name":   "",
@@ -26,11 +26,10 @@ func RegisterTaskQueueMetrics(metricStorage *metric_storage.MetricStorage) {
 		},
 		[]float64{
 			0.0,
-			0.000001, 0.000002, 0.000005, // 1,2,5 microseconds
-			0.00001, 0.00002, 0.00005, // 10,20,50 microseconds
 			0.0001, 0.0002, 0.0005, // 100, 200, 500 microseconds
 			0.001, 0.002, 0.005, // 1,2,5 milliseconds
 			0.01, 0.02, 0.05, // 10,20,50 milliseconds
+			0.1, 0.2, 0.5, // 100,200,500 milliseconds
 		},
 	)
 
@@ -44,7 +43,7 @@ func RegisterKubeEventsManagerMetrics(metricStorage *metric_storage.MetricStorag
 	// Size of snapshot in JSON format.
 	metricStorage.RegisterGauge("{PREFIX}kube_snapshot_bytes", labels)
 	// Duration of jqFilter applying.
-	metricStorage.RegisterHistogramWithBuckets(
+	metricStorage.RegisterHistogram(
 		"{PREFIX}kube_jq_filter_duration_seconds",
 		labels,
 		[]float64{
@@ -52,13 +51,11 @@ func RegisterKubeEventsManagerMetrics(metricStorage *metric_storage.MetricStorag
 			0.001, 0.002, 0.005, // 1,2,5 milliseconds
 			0.01, 0.02, 0.05, // 10,20,50 milliseconds
 			0.1, 0.2, 0.5, // 100,200,500 milliseconds
-			1, 2, 5, // 1,2,5 seconds
-			10, 20, 50, // 10, 20, 50 seconds
-			100, 200, 500, // 100,200,500 seconds
+			1, 2, 5, 10, // 1,2,5,10 seconds
 		},
 	)
 	// Duration of handling kubernetes event.
-	metricStorage.RegisterHistogramWithBuckets(
+	metricStorage.RegisterHistogram(
 		"{PREFIX}kube_event_duration_seconds",
 		labels,
 		[]float64{
@@ -66,9 +63,7 @@ func RegisterKubeEventsManagerMetrics(metricStorage *metric_storage.MetricStorag
 			0.001, 0.002, 0.005, // 1,2,5 milliseconds
 			0.01, 0.02, 0.05, // 10,20,50 milliseconds
 			0.1, 0.2, 0.5, // 100,200,500 milliseconds
-			1, 2, 5, // 1,2,5 seconds
-			10, 20, 50, // 10, 20, 50 seconds
-			100, 200, 500, // 100,200,500 seconds
+			1, 2, 5, 10, // 1,2,5,10 seconds
 		},
 	)
 }
@@ -87,13 +82,12 @@ func RegisterHookMetrics(metricStorage *metric_storage.MetricStorage) {
 		"queue":   "",
 	}
 	// Duration of hook execution.
-	metricStorage.RegisterHistogramWithBuckets(
+	metricStorage.RegisterHistogram(
 		"{PREFIX}hook_run_seconds",
 		labels,
 		[]float64{
 			0.0,
-			0.001, 0.002, 0.005, // 1,2,5 milliseconds
-			0.01, 0.02, 0.05, // 10,20,50 milliseconds
+			0.02, 0.05, // 20,50 milliseconds
 			0.1, 0.2, 0.5, // 100,200,500 milliseconds
 			1, 2, 5, // 1,2,5 seconds
 			10, 20, 50, // 10,20,50 seconds
@@ -102,13 +96,12 @@ func RegisterHookMetrics(metricStorage *metric_storage.MetricStorage) {
 	)
 
 	// System CPU usage.
-	metricStorage.RegisterHistogramWithBuckets(
+	metricStorage.RegisterHistogram(
 		"{PREFIX}hook_run_user_cpu_seconds",
 		labels,
 		[]float64{
 			0.0,
-			0.001, 0.002, 0.005, // 1,2,5 milliseconds
-			0.01, 0.02, 0.05, // 10,20,50 milliseconds
+			0.02, 0.05, // 20,50 milliseconds
 			0.1, 0.2, 0.5, // 100,200,500 milliseconds
 			1, 2, 5, // 1,2,5 seconds
 			10, 20, 50, // 10,20,50 seconds
@@ -116,13 +109,12 @@ func RegisterHookMetrics(metricStorage *metric_storage.MetricStorage) {
 		},
 	)
 	// User CPU usage.
-	metricStorage.RegisterHistogramWithBuckets(
+	metricStorage.RegisterHistogram(
 		"{PREFIX}hook_run_sys_cpu_seconds",
 		labels,
 		[]float64{
 			0.0,
-			0.001, 0.002, 0.005, // 1,2,5 milliseconds
-			0.01, 0.02, 0.05, // 10,20,50 milliseconds
+			0.02, 0.05, // 20,50 milliseconds
 			0.1, 0.2, 0.5, // 100,200,500 milliseconds
 			1, 2, 5, // 1,2,5 seconds
 			10, 20, 50, // 10,20,50 seconds

--- a/pkg/shell-operator/operator.go
+++ b/pkg/shell-operator/operator.go
@@ -647,7 +647,7 @@ func (op *ShellOperator) TaskHandleHookRun(t task.Task) queue.TaskResult {
 	op.MetricStorage.CounterAdd("{PREFIX}task_wait_in_queue_seconds_total", taskWaitTime, metricLabels)
 
 	defer measure.Duration(func(d time.Duration) {
-		op.MetricStorage.HistogramObserve("{PREFIX}hook_run_seconds", d.Seconds(), metricLabels)
+		op.MetricStorage.HistogramObserve("{PREFIX}hook_run_seconds", d.Seconds(), metricLabels, nil)
 	})()
 
 	hookLogLabels := map[string]string{}
@@ -746,8 +746,8 @@ func (op *ShellOperator) HandleRunHook(t task.Task, taskHook *hook.Hook, hookMet
 
 	if result != nil && result.Usage != nil {
 		taskLogEntry.Infof("Usage: %+v", result.Usage)
-		op.MetricStorage.HistogramObserve("{PREFIX}hook_run_sys_seconds", result.Usage.Sys.Seconds(), metricLabels)
-		op.MetricStorage.HistogramObserve("{PREFIX}hook_run_user_seconds", result.Usage.User.Seconds(), metricLabels)
+		op.MetricStorage.HistogramObserve("{PREFIX}hook_run_sys_seconds", result.Usage.Sys.Seconds(), metricLabels, nil)
+		op.MetricStorage.HistogramObserve("{PREFIX}hook_run_user_seconds", result.Usage.User.Seconds(), metricLabels, nil)
 		op.MetricStorage.GaugeSet("{PREFIX}hook_run_max_rss_bytes", float64(result.Usage.MaxRss)*1024, metricLabels)
 	}
 

--- a/pkg/task/queue/task_queue.go
+++ b/pkg/task/queue/task_queue.go
@@ -109,7 +109,7 @@ func (q *TaskQueue) MeasureActionTime(action string) func() {
 			q.measureActionFn = func() {}
 		} else {
 			q.measureActionFn = measure.Duration(func(d time.Duration) {
-				q.metricStorage.HistogramObserve("{PREFIX}tasks_queue_action_duration_seconds", d.Seconds(), map[string]string{"queue_name": q.Name, "queue_action": action})
+				q.metricStorage.HistogramObserve("{PREFIX}tasks_queue_action_duration_seconds", d.Seconds(), map[string]string{"queue_name": q.Name, "queue_action": action}, nil)
 			})
 		}
 	})


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

These changes add support for using the observe action on custom metrics from hooks

#### What this PR does / why we need it

For custom metrics, we have the "add", "set" (and "expire") actions available in the hook, which correspond to counters and gauges respectively. In order to observe a duration from inside the hook into a custom metric, this PR adds support for the "observe" action. This is useful for wanting to observe durations for different parts of the hook's code.

Additionally, there are a few unrelated minor changes (increasing durations of buckets to cover usecases of longer-running hooks for "core" metrics), .gitignore and a couple of typos

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
Add support for observing a histogram duration in custom, non-grouped metrics

```