### PR TITLE
Generate full resources not only preferred

### DIFF
--- a/pkg/kube/fake/scripts/resources_generator
+++ b/pkg/kube/fake/scripts/resources_generator
@@ -92,7 +92,7 @@ if ! kubectl version >> /dev/null ; then
   error_log 'kubectl must be installed and must be allowed to connect to kube-apiserver'
 fi
 
-readarray -t api_versions < <(kubectl get --raw /apis | jq -r '.groups[].preferredVersion.groupVersion')
+readarray -t api_versions < <(kubectl get --raw /apis | jq -r '.groups[].versions[].groupVersion')
 readarray -t namespaces < <(kubectl get ns --no-headers | awk '{print $1}')
 serverVersion=$(kubectl version --short | grep Server | awk '{print $3}' | cut -c 1,2,4,5)
 
@@ -114,3 +114,5 @@ for path in "${api_versions[@]}"; do
   print_group "$resources" "$path" >> $resFile
 done
 echo '}' >> $resFile
+
+go fmt $resFile

--- a/pkg/kube/fake/v116_resources.go
+++ b/pkg/kube/fake/v116_resources.go
@@ -158,6 +158,19 @@ var v116ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "apiregistration.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "APIService",
+				Name:       "apiservices",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "apiregistration.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
 		GroupVersion: "extensions/v1beta1",
 		APIResources: []metav1.APIResource{
 			{
@@ -242,6 +255,19 @@ var v116ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "authentication.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "TokenReview",
+				Name:       "tokenreviews",
+				Verbs:      metav1.Verbs{"create"},
+				Group:      "v1beta1",
+				Version:    "authentication.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
 		GroupVersion: "authorization.k8s.io/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -279,6 +305,43 @@ var v116ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "authorization.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "LocalSubjectAccessReview",
+				Name:       "localsubjectaccessreviews",
+				Verbs:      metav1.Verbs{"create"},
+				Group:      "v1beta1",
+				Version:    "authorization.k8s.io",
+				Namespaced: true,
+			},
+			{
+				Kind:       "SelfSubjectAccessReview",
+				Name:       "selfsubjectaccessreviews",
+				Verbs:      metav1.Verbs{"create"},
+				Group:      "v1beta1",
+				Version:    "authorization.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "SelfSubjectRulesReview",
+				Name:       "selfsubjectrulesreviews",
+				Verbs:      metav1.Verbs{"create"},
+				Group:      "v1beta1",
+				Version:    "authorization.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "SubjectAccessReview",
+				Name:       "subjectaccessreviews",
+				Verbs:      metav1.Verbs{"create"},
+				Group:      "v1beta1",
+				Version:    "authorization.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
 		GroupVersion: "autoscaling/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -292,6 +355,32 @@ var v116ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "autoscaling/v2beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "HorizontalPodAutoscaler",
+				Name:       "horizontalpodautoscalers",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v2beta1",
+				Version:    "autoscaling",
+				Namespaced: true,
+			},
+		},
+	},
+	{
+		GroupVersion: "autoscaling/v2beta2",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "HorizontalPodAutoscaler",
+				Name:       "horizontalpodautoscalers",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v2beta2",
+				Version:    "autoscaling",
+				Namespaced: true,
+			},
+		},
+	},
+	{
 		GroupVersion: "batch/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -299,6 +388,19 @@ var v116ClusterResources = []*metav1.APIResourceList{
 				Name:       "jobs",
 				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
 				Group:      "v1",
+				Version:    "batch",
+				Namespaced: true,
+			},
+		},
+	},
+	{
+		GroupVersion: "batch/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "CronJob",
+				Name:       "cronjobs",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
 				Version:    "batch",
 				Namespaced: true,
 			},
@@ -325,6 +427,19 @@ var v116ClusterResources = []*metav1.APIResourceList{
 				Name:       "networkpolicies",
 				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
 				Group:      "v1",
+				Version:    "networking.k8s.io",
+				Namespaced: true,
+			},
+		},
+	},
+	{
+		GroupVersion: "networking.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "Ingress",
+				Name:       "ingresses",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
 				Version:    "networking.k8s.io",
 				Namespaced: true,
 			},
@@ -389,6 +504,43 @@ var v116ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "rbac.authorization.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "ClusterRoleBinding",
+				Name:       "clusterrolebindings",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "rbac.authorization.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "ClusterRole",
+				Name:       "clusterroles",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "rbac.authorization.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "RoleBinding",
+				Name:       "rolebindings",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "rbac.authorization.k8s.io",
+				Namespaced: true,
+			},
+			{
+				Kind:       "Role",
+				Name:       "roles",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "rbac.authorization.k8s.io",
+				Namespaced: true,
+			},
+		},
+	},
+	{
 		GroupVersion: "storage.k8s.io/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -404,6 +556,43 @@ var v116ClusterResources = []*metav1.APIResourceList{
 				Name:       "volumeattachments",
 				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
 				Group:      "v1",
+				Version:    "storage.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
+		GroupVersion: "storage.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "CSIDriver",
+				Name:       "csidrivers",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "storage.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "CSINode",
+				Name:       "csinodes",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "storage.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "StorageClass",
+				Name:       "storageclasses",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "storage.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "VolumeAttachment",
+				Name:       "volumeattachments",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
 				Version:    "storage.k8s.io",
 				Namespaced: false,
 			},
@@ -431,6 +620,27 @@ var v116ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "admissionregistration.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "MutatingWebhookConfiguration",
+				Name:       "mutatingwebhookconfigurations",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "admissionregistration.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "ValidatingWebhookConfiguration",
+				Name:       "validatingwebhookconfigurations",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "admissionregistration.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
 		GroupVersion: "apiextensions.k8s.io/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -438,6 +648,19 @@ var v116ClusterResources = []*metav1.APIResourceList{
 				Name:       "customresourcedefinitions",
 				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
 				Group:      "v1",
+				Version:    "apiextensions.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
+		GroupVersion: "apiextensions.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "CustomResourceDefinition",
+				Name:       "customresourcedefinitions",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
 				Version:    "apiextensions.k8s.io",
 				Namespaced: false,
 			},
@@ -457,6 +680,19 @@ var v116ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "scheduling.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "PriorityClass",
+				Name:       "priorityclasses",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "scheduling.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
 		GroupVersion: "coordination.k8s.io/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -464,6 +700,19 @@ var v116ClusterResources = []*metav1.APIResourceList{
 				Name:       "leases",
 				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
 				Group:      "v1",
+				Version:    "coordination.k8s.io",
+				Namespaced: true,
+			},
+		},
+	},
+	{
+		GroupVersion: "coordination.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "Lease",
+				Name:       "leases",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
 				Version:    "coordination.k8s.io",
 				Namespaced: true,
 			},

--- a/pkg/kube/fake/v117_resources.go
+++ b/pkg/kube/fake/v117_resources.go
@@ -158,6 +158,19 @@ var v117ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "apiregistration.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "APIService",
+				Name:       "apiservices",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "apiregistration.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
 		GroupVersion: "extensions/v1beta1",
 		APIResources: []metav1.APIResource{
 			{
@@ -242,6 +255,19 @@ var v117ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "authentication.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "TokenReview",
+				Name:       "tokenreviews",
+				Verbs:      metav1.Verbs{"create"},
+				Group:      "v1beta1",
+				Version:    "authentication.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
 		GroupVersion: "authorization.k8s.io/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -279,6 +305,43 @@ var v117ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "authorization.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "LocalSubjectAccessReview",
+				Name:       "localsubjectaccessreviews",
+				Verbs:      metav1.Verbs{"create"},
+				Group:      "v1beta1",
+				Version:    "authorization.k8s.io",
+				Namespaced: true,
+			},
+			{
+				Kind:       "SelfSubjectAccessReview",
+				Name:       "selfsubjectaccessreviews",
+				Verbs:      metav1.Verbs{"create"},
+				Group:      "v1beta1",
+				Version:    "authorization.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "SelfSubjectRulesReview",
+				Name:       "selfsubjectrulesreviews",
+				Verbs:      metav1.Verbs{"create"},
+				Group:      "v1beta1",
+				Version:    "authorization.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "SubjectAccessReview",
+				Name:       "subjectaccessreviews",
+				Verbs:      metav1.Verbs{"create"},
+				Group:      "v1beta1",
+				Version:    "authorization.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
 		GroupVersion: "autoscaling/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -292,6 +355,32 @@ var v117ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "autoscaling/v2beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "HorizontalPodAutoscaler",
+				Name:       "horizontalpodautoscalers",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v2beta1",
+				Version:    "autoscaling",
+				Namespaced: true,
+			},
+		},
+	},
+	{
+		GroupVersion: "autoscaling/v2beta2",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "HorizontalPodAutoscaler",
+				Name:       "horizontalpodautoscalers",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v2beta2",
+				Version:    "autoscaling",
+				Namespaced: true,
+			},
+		},
+	},
+	{
 		GroupVersion: "batch/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -299,6 +388,19 @@ var v117ClusterResources = []*metav1.APIResourceList{
 				Name:       "jobs",
 				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
 				Group:      "v1",
+				Version:    "batch",
+				Namespaced: true,
+			},
+		},
+	},
+	{
+		GroupVersion: "batch/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "CronJob",
+				Name:       "cronjobs",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
 				Version:    "batch",
 				Namespaced: true,
 			},
@@ -325,6 +427,19 @@ var v117ClusterResources = []*metav1.APIResourceList{
 				Name:       "networkpolicies",
 				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
 				Group:      "v1",
+				Version:    "networking.k8s.io",
+				Namespaced: true,
+			},
+		},
+	},
+	{
+		GroupVersion: "networking.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "Ingress",
+				Name:       "ingresses",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
 				Version:    "networking.k8s.io",
 				Namespaced: true,
 			},
@@ -389,6 +504,43 @@ var v117ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "rbac.authorization.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "ClusterRoleBinding",
+				Name:       "clusterrolebindings",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "rbac.authorization.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "ClusterRole",
+				Name:       "clusterroles",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "rbac.authorization.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "RoleBinding",
+				Name:       "rolebindings",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "rbac.authorization.k8s.io",
+				Namespaced: true,
+			},
+			{
+				Kind:       "Role",
+				Name:       "roles",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "rbac.authorization.k8s.io",
+				Namespaced: true,
+			},
+		},
+	},
+	{
 		GroupVersion: "storage.k8s.io/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -418,6 +570,43 @@ var v117ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "storage.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "CSIDriver",
+				Name:       "csidrivers",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "storage.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "CSINode",
+				Name:       "csinodes",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "storage.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "StorageClass",
+				Name:       "storageclasses",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "storage.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "VolumeAttachment",
+				Name:       "volumeattachments",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "storage.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
 		GroupVersion: "admissionregistration.k8s.io/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -439,6 +628,27 @@ var v117ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "admissionregistration.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "MutatingWebhookConfiguration",
+				Name:       "mutatingwebhookconfigurations",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "admissionregistration.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "ValidatingWebhookConfiguration",
+				Name:       "validatingwebhookconfigurations",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "admissionregistration.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
 		GroupVersion: "apiextensions.k8s.io/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -446,6 +656,19 @@ var v117ClusterResources = []*metav1.APIResourceList{
 				Name:       "customresourcedefinitions",
 				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
 				Group:      "v1",
+				Version:    "apiextensions.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
+		GroupVersion: "apiextensions.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "CustomResourceDefinition",
+				Name:       "customresourcedefinitions",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
 				Version:    "apiextensions.k8s.io",
 				Namespaced: false,
 			},
@@ -465,6 +688,19 @@ var v117ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "scheduling.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "PriorityClass",
+				Name:       "priorityclasses",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "scheduling.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
 		GroupVersion: "coordination.k8s.io/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -472,6 +708,19 @@ var v117ClusterResources = []*metav1.APIResourceList{
 				Name:       "leases",
 				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
 				Group:      "v1",
+				Version:    "coordination.k8s.io",
+				Namespaced: true,
+			},
+		},
+	},
+	{
+		GroupVersion: "coordination.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "Lease",
+				Name:       "leases",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
 				Version:    "coordination.k8s.io",
 				Namespaced: true,
 			},

--- a/pkg/kube/fake/v118_resources.go
+++ b/pkg/kube/fake/v118_resources.go
@@ -158,6 +158,19 @@ var v118ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "apiregistration.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "APIService",
+				Name:       "apiservices",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "apiregistration.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
 		GroupVersion: "extensions/v1beta1",
 		APIResources: []metav1.APIResource{
 			{
@@ -242,6 +255,19 @@ var v118ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "authentication.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "TokenReview",
+				Name:       "tokenreviews",
+				Verbs:      metav1.Verbs{"create"},
+				Group:      "v1beta1",
+				Version:    "authentication.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
 		GroupVersion: "authorization.k8s.io/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -279,6 +305,43 @@ var v118ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "authorization.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "LocalSubjectAccessReview",
+				Name:       "localsubjectaccessreviews",
+				Verbs:      metav1.Verbs{"create"},
+				Group:      "v1beta1",
+				Version:    "authorization.k8s.io",
+				Namespaced: true,
+			},
+			{
+				Kind:       "SelfSubjectAccessReview",
+				Name:       "selfsubjectaccessreviews",
+				Verbs:      metav1.Verbs{"create"},
+				Group:      "v1beta1",
+				Version:    "authorization.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "SelfSubjectRulesReview",
+				Name:       "selfsubjectrulesreviews",
+				Verbs:      metav1.Verbs{"create"},
+				Group:      "v1beta1",
+				Version:    "authorization.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "SubjectAccessReview",
+				Name:       "subjectaccessreviews",
+				Verbs:      metav1.Verbs{"create"},
+				Group:      "v1beta1",
+				Version:    "authorization.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
 		GroupVersion: "autoscaling/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -292,6 +355,32 @@ var v118ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "autoscaling/v2beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "HorizontalPodAutoscaler",
+				Name:       "horizontalpodautoscalers",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v2beta1",
+				Version:    "autoscaling",
+				Namespaced: true,
+			},
+		},
+	},
+	{
+		GroupVersion: "autoscaling/v2beta2",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "HorizontalPodAutoscaler",
+				Name:       "horizontalpodautoscalers",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v2beta2",
+				Version:    "autoscaling",
+				Namespaced: true,
+			},
+		},
+	},
+	{
 		GroupVersion: "batch/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -299,6 +388,19 @@ var v118ClusterResources = []*metav1.APIResourceList{
 				Name:       "jobs",
 				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
 				Group:      "v1",
+				Version:    "batch",
+				Namespaced: true,
+			},
+		},
+	},
+	{
+		GroupVersion: "batch/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "CronJob",
+				Name:       "cronjobs",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
 				Version:    "batch",
 				Namespaced: true,
 			},
@@ -325,6 +427,27 @@ var v118ClusterResources = []*metav1.APIResourceList{
 				Name:       "networkpolicies",
 				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
 				Group:      "v1",
+				Version:    "networking.k8s.io",
+				Namespaced: true,
+			},
+		},
+	},
+	{
+		GroupVersion: "networking.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "IngressClass",
+				Name:       "ingressclasses",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "networking.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "Ingress",
+				Name:       "ingresses",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
 				Version:    "networking.k8s.io",
 				Namespaced: true,
 			},
@@ -389,6 +512,43 @@ var v118ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "rbac.authorization.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "ClusterRoleBinding",
+				Name:       "clusterrolebindings",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "rbac.authorization.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "ClusterRole",
+				Name:       "clusterroles",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "rbac.authorization.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "RoleBinding",
+				Name:       "rolebindings",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "rbac.authorization.k8s.io",
+				Namespaced: true,
+			},
+			{
+				Kind:       "Role",
+				Name:       "roles",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "rbac.authorization.k8s.io",
+				Namespaced: true,
+			},
+		},
+	},
+	{
 		GroupVersion: "storage.k8s.io/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -426,6 +586,43 @@ var v118ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "storage.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "CSIDriver",
+				Name:       "csidrivers",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "storage.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "CSINode",
+				Name:       "csinodes",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "storage.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "StorageClass",
+				Name:       "storageclasses",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "storage.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "VolumeAttachment",
+				Name:       "volumeattachments",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "storage.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
 		GroupVersion: "admissionregistration.k8s.io/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -447,6 +644,27 @@ var v118ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "admissionregistration.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "MutatingWebhookConfiguration",
+				Name:       "mutatingwebhookconfigurations",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "admissionregistration.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "ValidatingWebhookConfiguration",
+				Name:       "validatingwebhookconfigurations",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "admissionregistration.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
 		GroupVersion: "apiextensions.k8s.io/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -454,6 +672,19 @@ var v118ClusterResources = []*metav1.APIResourceList{
 				Name:       "customresourcedefinitions",
 				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
 				Group:      "v1",
+				Version:    "apiextensions.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
+		GroupVersion: "apiextensions.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "CustomResourceDefinition",
+				Name:       "customresourcedefinitions",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
 				Version:    "apiextensions.k8s.io",
 				Namespaced: false,
 			},
@@ -473,6 +704,19 @@ var v118ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "scheduling.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "PriorityClass",
+				Name:       "priorityclasses",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "scheduling.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
 		GroupVersion: "coordination.k8s.io/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -480,6 +724,19 @@ var v118ClusterResources = []*metav1.APIResourceList{
 				Name:       "leases",
 				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
 				Group:      "v1",
+				Version:    "coordination.k8s.io",
+				Namespaced: true,
+			},
+		},
+	},
+	{
+		GroupVersion: "coordination.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "Lease",
+				Name:       "leases",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
 				Version:    "coordination.k8s.io",
 				Namespaced: true,
 			},

--- a/pkg/kube/fake/v119_resources.go
+++ b/pkg/kube/fake/v119_resources.go
@@ -158,6 +158,19 @@ var v119ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "apiregistration.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "APIService",
+				Name:       "apiservices",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "apiregistration.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
 		GroupVersion: "extensions/v1beta1",
 		APIResources: []metav1.APIResource{
 			{
@@ -229,6 +242,19 @@ var v119ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "events.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "Event",
+				Name:       "events",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "events.k8s.io",
+				Namespaced: true,
+			},
+		},
+	},
+	{
 		GroupVersion: "authentication.k8s.io/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -236,6 +262,19 @@ var v119ClusterResources = []*metav1.APIResourceList{
 				Name:       "tokenreviews",
 				Verbs:      metav1.Verbs{"create"},
 				Group:      "v1",
+				Version:    "authentication.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
+		GroupVersion: "authentication.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "TokenReview",
+				Name:       "tokenreviews",
+				Verbs:      metav1.Verbs{"create"},
+				Group:      "v1beta1",
 				Version:    "authentication.k8s.io",
 				Namespaced: false,
 			},
@@ -279,6 +318,43 @@ var v119ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "authorization.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "LocalSubjectAccessReview",
+				Name:       "localsubjectaccessreviews",
+				Verbs:      metav1.Verbs{"create"},
+				Group:      "v1beta1",
+				Version:    "authorization.k8s.io",
+				Namespaced: true,
+			},
+			{
+				Kind:       "SelfSubjectAccessReview",
+				Name:       "selfsubjectaccessreviews",
+				Verbs:      metav1.Verbs{"create"},
+				Group:      "v1beta1",
+				Version:    "authorization.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "SelfSubjectRulesReview",
+				Name:       "selfsubjectrulesreviews",
+				Verbs:      metav1.Verbs{"create"},
+				Group:      "v1beta1",
+				Version:    "authorization.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "SubjectAccessReview",
+				Name:       "subjectaccessreviews",
+				Verbs:      metav1.Verbs{"create"},
+				Group:      "v1beta1",
+				Version:    "authorization.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
 		GroupVersion: "autoscaling/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -286,6 +362,32 @@ var v119ClusterResources = []*metav1.APIResourceList{
 				Name:       "horizontalpodautoscalers",
 				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
 				Group:      "v1",
+				Version:    "autoscaling",
+				Namespaced: true,
+			},
+		},
+	},
+	{
+		GroupVersion: "autoscaling/v2beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "HorizontalPodAutoscaler",
+				Name:       "horizontalpodautoscalers",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v2beta1",
+				Version:    "autoscaling",
+				Namespaced: true,
+			},
+		},
+	},
+	{
+		GroupVersion: "autoscaling/v2beta2",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "HorizontalPodAutoscaler",
+				Name:       "horizontalpodautoscalers",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v2beta2",
 				Version:    "autoscaling",
 				Namespaced: true,
 			},
@@ -305,6 +407,19 @@ var v119ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "batch/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "CronJob",
+				Name:       "cronjobs",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "batch",
+				Namespaced: true,
+			},
+		},
+	},
+	{
 		GroupVersion: "certificates.k8s.io/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -312,6 +427,19 @@ var v119ClusterResources = []*metav1.APIResourceList{
 				Name:       "certificatesigningrequests",
 				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
 				Group:      "v1",
+				Version:    "certificates.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
+		GroupVersion: "certificates.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "CertificateSigningRequest",
+				Name:       "certificatesigningrequests",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
 				Version:    "certificates.k8s.io",
 				Namespaced: false,
 			},
@@ -341,6 +469,27 @@ var v119ClusterResources = []*metav1.APIResourceList{
 				Name:       "networkpolicies",
 				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
 				Group:      "v1",
+				Version:    "networking.k8s.io",
+				Namespaced: true,
+			},
+		},
+	},
+	{
+		GroupVersion: "networking.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "IngressClass",
+				Name:       "ingressclasses",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "networking.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "Ingress",
+				Name:       "ingresses",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
 				Version:    "networking.k8s.io",
 				Namespaced: true,
 			},
@@ -405,6 +554,43 @@ var v119ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "rbac.authorization.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "ClusterRoleBinding",
+				Name:       "clusterrolebindings",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "rbac.authorization.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "ClusterRole",
+				Name:       "clusterroles",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "rbac.authorization.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "RoleBinding",
+				Name:       "rolebindings",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "rbac.authorization.k8s.io",
+				Namespaced: true,
+			},
+			{
+				Kind:       "Role",
+				Name:       "roles",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "rbac.authorization.k8s.io",
+				Namespaced: true,
+			},
+		},
+	},
+	{
 		GroupVersion: "storage.k8s.io/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -442,6 +628,43 @@ var v119ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "storage.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "CSIDriver",
+				Name:       "csidrivers",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "storage.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "CSINode",
+				Name:       "csinodes",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "storage.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "StorageClass",
+				Name:       "storageclasses",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "storage.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "VolumeAttachment",
+				Name:       "volumeattachments",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "storage.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
 		GroupVersion: "admissionregistration.k8s.io/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -463,6 +686,27 @@ var v119ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "admissionregistration.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "MutatingWebhookConfiguration",
+				Name:       "mutatingwebhookconfigurations",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "admissionregistration.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "ValidatingWebhookConfiguration",
+				Name:       "validatingwebhookconfigurations",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "admissionregistration.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
 		GroupVersion: "apiextensions.k8s.io/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -470,6 +714,19 @@ var v119ClusterResources = []*metav1.APIResourceList{
 				Name:       "customresourcedefinitions",
 				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
 				Group:      "v1",
+				Version:    "apiextensions.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
+		GroupVersion: "apiextensions.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "CustomResourceDefinition",
+				Name:       "customresourcedefinitions",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
 				Version:    "apiextensions.k8s.io",
 				Namespaced: false,
 			},
@@ -489,6 +746,19 @@ var v119ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "scheduling.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "PriorityClass",
+				Name:       "priorityclasses",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "scheduling.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
 		GroupVersion: "coordination.k8s.io/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -496,6 +766,19 @@ var v119ClusterResources = []*metav1.APIResourceList{
 				Name:       "leases",
 				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
 				Group:      "v1",
+				Version:    "coordination.k8s.io",
+				Namespaced: true,
+			},
+		},
+	},
+	{
+		GroupVersion: "coordination.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "Lease",
+				Name:       "leases",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
 				Version:    "coordination.k8s.io",
 				Namespaced: true,
 			},
@@ -531,16 +814,8 @@ var v119ClusterResources = []*metav1.APIResourceList{
 		GroupVersion: "crd.projectcalico.org/v1",
 		APIResources: []metav1.APIResource{
 			{
-				Kind:       "BGPConfiguration",
-				Name:       "bgpconfigurations",
-				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
-				Group:      "v1",
-				Version:    "crd.projectcalico.org",
-				Namespaced: false,
-			},
-			{
-				Kind:       "ClusterInformation",
-				Name:       "clusterinformations",
+				Kind:       "HostEndpoint",
+				Name:       "hostendpoints",
 				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
 				Group:      "v1",
 				Version:    "crd.projectcalico.org",
@@ -555,16 +830,24 @@ var v119ClusterResources = []*metav1.APIResourceList{
 				Namespaced: false,
 			},
 			{
-				Kind:       "HostEndpoint",
-				Name:       "hostendpoints",
+				Kind:       "GlobalNetworkPolicy",
+				Name:       "globalnetworkpolicies",
 				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
 				Group:      "v1",
 				Version:    "crd.projectcalico.org",
 				Namespaced: false,
 			},
 			{
-				Kind:       "NetworkSet",
-				Name:       "networksets",
+				Kind:       "IPPool",
+				Name:       "ippools",
+				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
+				Group:      "v1",
+				Version:    "crd.projectcalico.org",
+				Namespaced: false,
+			},
+			{
+				Kind:       "NetworkPolicy",
+				Name:       "networkpolicies",
 				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
 				Group:      "v1",
 				Version:    "crd.projectcalico.org",
@@ -579,8 +862,16 @@ var v119ClusterResources = []*metav1.APIResourceList{
 				Namespaced: false,
 			},
 			{
-				Kind:       "GlobalNetworkPolicy",
-				Name:       "globalnetworkpolicies",
+				Kind:       "ClusterInformation",
+				Name:       "clusterinformations",
+				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
+				Group:      "v1",
+				Version:    "crd.projectcalico.org",
+				Namespaced: false,
+			},
+			{
+				Kind:       "GlobalNetworkSet",
+				Name:       "globalnetworksets",
 				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
 				Group:      "v1",
 				Version:    "crd.projectcalico.org",
@@ -611,6 +902,14 @@ var v119ClusterResources = []*metav1.APIResourceList{
 				Namespaced: false,
 			},
 			{
+				Kind:       "BGPConfiguration",
+				Name:       "bgpconfigurations",
+				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
+				Group:      "v1",
+				Version:    "crd.projectcalico.org",
+				Namespaced: false,
+			},
+			{
 				Kind:       "BGPPeer",
 				Name:       "bgppeers",
 				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
@@ -619,24 +918,8 @@ var v119ClusterResources = []*metav1.APIResourceList{
 				Namespaced: false,
 			},
 			{
-				Kind:       "GlobalNetworkSet",
-				Name:       "globalnetworksets",
-				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
-				Group:      "v1",
-				Version:    "crd.projectcalico.org",
-				Namespaced: false,
-			},
-			{
-				Kind:       "IPPool",
-				Name:       "ippools",
-				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
-				Group:      "v1",
-				Version:    "crd.projectcalico.org",
-				Namespaced: false,
-			},
-			{
-				Kind:       "NetworkPolicy",
-				Name:       "networkpolicies",
+				Kind:       "NetworkSet",
+				Name:       "networksets",
 				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
 				Group:      "v1",
 				Version:    "crd.projectcalico.org",

--- a/pkg/kube/fake/v120_resources.go
+++ b/pkg/kube/fake/v120_resources.go
@@ -158,6 +158,19 @@ var v120ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "apiregistration.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "APIService",
+				Name:       "apiservices",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "apiregistration.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
 		GroupVersion: "apps/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -216,6 +229,19 @@ var v120ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "events.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "Event",
+				Name:       "events",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "events.k8s.io",
+				Namespaced: true,
+			},
+		},
+	},
+	{
 		GroupVersion: "authentication.k8s.io/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -223,6 +249,19 @@ var v120ClusterResources = []*metav1.APIResourceList{
 				Name:       "tokenreviews",
 				Verbs:      metav1.Verbs{"create"},
 				Group:      "v1",
+				Version:    "authentication.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
+		GroupVersion: "authentication.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "TokenReview",
+				Name:       "tokenreviews",
+				Verbs:      metav1.Verbs{"create"},
+				Group:      "v1beta1",
 				Version:    "authentication.k8s.io",
 				Namespaced: false,
 			},
@@ -266,6 +305,43 @@ var v120ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "authorization.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "LocalSubjectAccessReview",
+				Name:       "localsubjectaccessreviews",
+				Verbs:      metav1.Verbs{"create"},
+				Group:      "v1beta1",
+				Version:    "authorization.k8s.io",
+				Namespaced: true,
+			},
+			{
+				Kind:       "SelfSubjectAccessReview",
+				Name:       "selfsubjectaccessreviews",
+				Verbs:      metav1.Verbs{"create"},
+				Group:      "v1beta1",
+				Version:    "authorization.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "SelfSubjectRulesReview",
+				Name:       "selfsubjectrulesreviews",
+				Verbs:      metav1.Verbs{"create"},
+				Group:      "v1beta1",
+				Version:    "authorization.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "SubjectAccessReview",
+				Name:       "subjectaccessreviews",
+				Verbs:      metav1.Verbs{"create"},
+				Group:      "v1beta1",
+				Version:    "authorization.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
 		GroupVersion: "autoscaling/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -273,6 +349,32 @@ var v120ClusterResources = []*metav1.APIResourceList{
 				Name:       "horizontalpodautoscalers",
 				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
 				Group:      "v1",
+				Version:    "autoscaling",
+				Namespaced: true,
+			},
+		},
+	},
+	{
+		GroupVersion: "autoscaling/v2beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "HorizontalPodAutoscaler",
+				Name:       "horizontalpodautoscalers",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v2beta1",
+				Version:    "autoscaling",
+				Namespaced: true,
+			},
+		},
+	},
+	{
+		GroupVersion: "autoscaling/v2beta2",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "HorizontalPodAutoscaler",
+				Name:       "horizontalpodautoscalers",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v2beta2",
 				Version:    "autoscaling",
 				Namespaced: true,
 			},
@@ -292,6 +394,19 @@ var v120ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "batch/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "CronJob",
+				Name:       "cronjobs",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "batch",
+				Namespaced: true,
+			},
+		},
+	},
+	{
 		GroupVersion: "certificates.k8s.io/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -299,6 +414,19 @@ var v120ClusterResources = []*metav1.APIResourceList{
 				Name:       "certificatesigningrequests",
 				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
 				Group:      "v1",
+				Version:    "certificates.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
+		GroupVersion: "certificates.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "CertificateSigningRequest",
+				Name:       "certificatesigningrequests",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
 				Version:    "certificates.k8s.io",
 				Namespaced: false,
 			},
@@ -328,6 +456,27 @@ var v120ClusterResources = []*metav1.APIResourceList{
 				Name:       "networkpolicies",
 				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
 				Group:      "v1",
+				Version:    "networking.k8s.io",
+				Namespaced: true,
+			},
+		},
+	},
+	{
+		GroupVersion: "networking.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "IngressClass",
+				Name:       "ingressclasses",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "networking.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "Ingress",
+				Name:       "ingresses",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
 				Version:    "networking.k8s.io",
 				Namespaced: true,
 			},
@@ -405,6 +554,43 @@ var v120ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "rbac.authorization.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "ClusterRoleBinding",
+				Name:       "clusterrolebindings",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "rbac.authorization.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "ClusterRole",
+				Name:       "clusterroles",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "rbac.authorization.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "RoleBinding",
+				Name:       "rolebindings",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "rbac.authorization.k8s.io",
+				Namespaced: true,
+			},
+			{
+				Kind:       "Role",
+				Name:       "roles",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "rbac.authorization.k8s.io",
+				Namespaced: true,
+			},
+		},
+	},
+	{
 		GroupVersion: "storage.k8s.io/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -442,6 +628,43 @@ var v120ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "storage.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "CSIDriver",
+				Name:       "csidrivers",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "storage.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "CSINode",
+				Name:       "csinodes",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "storage.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "StorageClass",
+				Name:       "storageclasses",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "storage.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "VolumeAttachment",
+				Name:       "volumeattachments",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "storage.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
 		GroupVersion: "admissionregistration.k8s.io/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -463,6 +686,27 @@ var v120ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "admissionregistration.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "MutatingWebhookConfiguration",
+				Name:       "mutatingwebhookconfigurations",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "admissionregistration.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "ValidatingWebhookConfiguration",
+				Name:       "validatingwebhookconfigurations",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "admissionregistration.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
 		GroupVersion: "apiextensions.k8s.io/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -470,6 +714,19 @@ var v120ClusterResources = []*metav1.APIResourceList{
 				Name:       "customresourcedefinitions",
 				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
 				Group:      "v1",
+				Version:    "apiextensions.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
+		GroupVersion: "apiextensions.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "CustomResourceDefinition",
+				Name:       "customresourcedefinitions",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
 				Version:    "apiextensions.k8s.io",
 				Namespaced: false,
 			},
@@ -489,6 +746,19 @@ var v120ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "scheduling.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "PriorityClass",
+				Name:       "priorityclasses",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "scheduling.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
 		GroupVersion: "coordination.k8s.io/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -502,6 +772,19 @@ var v120ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "coordination.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "Lease",
+				Name:       "leases",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "coordination.k8s.io",
+				Namespaced: true,
+			},
+		},
+	},
+	{
 		GroupVersion: "node.k8s.io/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -509,6 +792,19 @@ var v120ClusterResources = []*metav1.APIResourceList{
 				Name:       "runtimeclasses",
 				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
 				Group:      "v1",
+				Version:    "node.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
+		GroupVersion: "node.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "RuntimeClass",
+				Name:       "runtimeclasses",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
 				Version:    "node.k8s.io",
 				Namespaced: false,
 			},
@@ -560,48 +856,8 @@ var v120ClusterResources = []*metav1.APIResourceList{
 				Namespaced: false,
 			},
 			{
-				Kind:       "IPAMHandle",
-				Name:       "ipamhandles",
-				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
-				Group:      "v1",
-				Version:    "crd.projectcalico.org",
-				Namespaced: false,
-			},
-			{
-				Kind:       "GlobalNetworkSet",
-				Name:       "globalnetworksets",
-				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
-				Group:      "v1",
-				Version:    "crd.projectcalico.org",
-				Namespaced: false,
-			},
-			{
-				Kind:       "IPAMBlock",
-				Name:       "ipamblocks",
-				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
-				Group:      "v1",
-				Version:    "crd.projectcalico.org",
-				Namespaced: false,
-			},
-			{
-				Kind:       "IPAMConfig",
-				Name:       "ipamconfigs",
-				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
-				Group:      "v1",
-				Version:    "crd.projectcalico.org",
-				Namespaced: false,
-			},
-			{
-				Kind:       "NetworkPolicy",
-				Name:       "networkpolicies",
-				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
-				Group:      "v1",
-				Version:    "crd.projectcalico.org",
-				Namespaced: true,
-			},
-			{
-				Kind:       "ClusterInformation",
-				Name:       "clusterinformations",
+				Kind:       "BlockAffinity",
+				Name:       "blockaffinities",
 				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
 				Group:      "v1",
 				Version:    "crd.projectcalico.org",
@@ -616,24 +872,16 @@ var v120ClusterResources = []*metav1.APIResourceList{
 				Namespaced: false,
 			},
 			{
-				Kind:       "GlobalNetworkPolicy",
-				Name:       "globalnetworkpolicies",
+				Kind:       "IPAMConfig",
+				Name:       "ipamconfigs",
 				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
 				Group:      "v1",
 				Version:    "crd.projectcalico.org",
 				Namespaced: false,
 			},
 			{
-				Kind:       "BGPPeer",
-				Name:       "bgppeers",
-				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
-				Group:      "v1",
-				Version:    "crd.projectcalico.org",
-				Namespaced: false,
-			},
-			{
-				Kind:       "HostEndpoint",
-				Name:       "hostendpoints",
+				Kind:       "IPAMHandle",
+				Name:       "ipamhandles",
 				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
 				Group:      "v1",
 				Version:    "crd.projectcalico.org",
@@ -648,16 +896,64 @@ var v120ClusterResources = []*metav1.APIResourceList{
 				Namespaced: false,
 			},
 			{
-				Kind:       "BlockAffinity",
-				Name:       "blockaffinities",
+				Kind:       "NetworkSet",
+				Name:       "networksets",
+				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
+				Group:      "v1",
+				Version:    "crd.projectcalico.org",
+				Namespaced: true,
+			},
+			{
+				Kind:       "GlobalNetworkPolicy",
+				Name:       "globalnetworkpolicies",
 				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
 				Group:      "v1",
 				Version:    "crd.projectcalico.org",
 				Namespaced: false,
 			},
 			{
-				Kind:       "NetworkSet",
-				Name:       "networksets",
+				Kind:       "GlobalNetworkSet",
+				Name:       "globalnetworksets",
+				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
+				Group:      "v1",
+				Version:    "crd.projectcalico.org",
+				Namespaced: false,
+			},
+			{
+				Kind:       "HostEndpoint",
+				Name:       "hostendpoints",
+				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
+				Group:      "v1",
+				Version:    "crd.projectcalico.org",
+				Namespaced: false,
+			},
+			{
+				Kind:       "BGPPeer",
+				Name:       "bgppeers",
+				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
+				Group:      "v1",
+				Version:    "crd.projectcalico.org",
+				Namespaced: false,
+			},
+			{
+				Kind:       "ClusterInformation",
+				Name:       "clusterinformations",
+				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
+				Group:      "v1",
+				Version:    "crd.projectcalico.org",
+				Namespaced: false,
+			},
+			{
+				Kind:       "IPAMBlock",
+				Name:       "ipamblocks",
+				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
+				Group:      "v1",
+				Version:    "crd.projectcalico.org",
+				Namespaced: false,
+			},
+			{
+				Kind:       "NetworkPolicy",
+				Name:       "networkpolicies",
 				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
 				Group:      "v1",
 				Version:    "crd.projectcalico.org",

--- a/pkg/kube/fake/v121_resources.go
+++ b/pkg/kube/fake/v121_resources.go
@@ -158,6 +158,19 @@ var v121ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "apiregistration.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "APIService",
+				Name:       "apiservices",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "apiregistration.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
 		GroupVersion: "apps/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -216,6 +229,19 @@ var v121ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "events.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "Event",
+				Name:       "events",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "events.k8s.io",
+				Namespaced: true,
+			},
+		},
+	},
+	{
 		GroupVersion: "authentication.k8s.io/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -223,6 +249,19 @@ var v121ClusterResources = []*metav1.APIResourceList{
 				Name:       "tokenreviews",
 				Verbs:      metav1.Verbs{"create"},
 				Group:      "v1",
+				Version:    "authentication.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
+		GroupVersion: "authentication.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "TokenReview",
+				Name:       "tokenreviews",
+				Verbs:      metav1.Verbs{"create"},
+				Group:      "v1beta1",
 				Version:    "authentication.k8s.io",
 				Namespaced: false,
 			},
@@ -266,6 +305,43 @@ var v121ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "authorization.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "LocalSubjectAccessReview",
+				Name:       "localsubjectaccessreviews",
+				Verbs:      metav1.Verbs{"create"},
+				Group:      "v1beta1",
+				Version:    "authorization.k8s.io",
+				Namespaced: true,
+			},
+			{
+				Kind:       "SelfSubjectAccessReview",
+				Name:       "selfsubjectaccessreviews",
+				Verbs:      metav1.Verbs{"create"},
+				Group:      "v1beta1",
+				Version:    "authorization.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "SelfSubjectRulesReview",
+				Name:       "selfsubjectrulesreviews",
+				Verbs:      metav1.Verbs{"create"},
+				Group:      "v1beta1",
+				Version:    "authorization.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "SubjectAccessReview",
+				Name:       "subjectaccessreviews",
+				Verbs:      metav1.Verbs{"create"},
+				Group:      "v1beta1",
+				Version:    "authorization.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
 		GroupVersion: "autoscaling/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -273,6 +349,32 @@ var v121ClusterResources = []*metav1.APIResourceList{
 				Name:       "horizontalpodautoscalers",
 				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
 				Group:      "v1",
+				Version:    "autoscaling",
+				Namespaced: true,
+			},
+		},
+	},
+	{
+		GroupVersion: "autoscaling/v2beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "HorizontalPodAutoscaler",
+				Name:       "horizontalpodautoscalers",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v2beta1",
+				Version:    "autoscaling",
+				Namespaced: true,
+			},
+		},
+	},
+	{
+		GroupVersion: "autoscaling/v2beta2",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "HorizontalPodAutoscaler",
+				Name:       "horizontalpodautoscalers",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v2beta2",
 				Version:    "autoscaling",
 				Namespaced: true,
 			},
@@ -300,6 +402,19 @@ var v121ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "batch/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "CronJob",
+				Name:       "cronjobs",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "batch",
+				Namespaced: true,
+			},
+		},
+	},
+	{
 		GroupVersion: "certificates.k8s.io/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -307,6 +422,19 @@ var v121ClusterResources = []*metav1.APIResourceList{
 				Name:       "certificatesigningrequests",
 				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
 				Group:      "v1",
+				Version:    "certificates.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
+		GroupVersion: "certificates.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "CertificateSigningRequest",
+				Name:       "certificatesigningrequests",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
 				Version:    "certificates.k8s.io",
 				Namespaced: false,
 			},
@@ -342,6 +470,27 @@ var v121ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "networking.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "IngressClass",
+				Name:       "ingressclasses",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "networking.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "Ingress",
+				Name:       "ingresses",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "networking.k8s.io",
+				Namespaced: true,
+			},
+		},
+	},
+	{
 		GroupVersion: "extensions/v1beta1",
 		APIResources: []metav1.APIResource{
 			{
@@ -364,6 +513,27 @@ var v121ClusterResources = []*metav1.APIResourceList{
 				Group:      "v1",
 				Version:    "policy",
 				Namespaced: true,
+			},
+		},
+	},
+	{
+		GroupVersion: "policy/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "PodDisruptionBudget",
+				Name:       "poddisruptionbudgets",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "policy",
+				Namespaced: true,
+			},
+			{
+				Kind:       "PodSecurityPolicy",
+				Name:       "podsecuritypolicies",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "policy",
+				Namespaced: false,
 			},
 		},
 	},
@@ -399,6 +569,43 @@ var v121ClusterResources = []*metav1.APIResourceList{
 				Name:       "roles",
 				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
 				Group:      "v1",
+				Version:    "rbac.authorization.k8s.io",
+				Namespaced: true,
+			},
+		},
+	},
+	{
+		GroupVersion: "rbac.authorization.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "ClusterRoleBinding",
+				Name:       "clusterrolebindings",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "rbac.authorization.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "ClusterRole",
+				Name:       "clusterroles",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "rbac.authorization.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "RoleBinding",
+				Name:       "rolebindings",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "rbac.authorization.k8s.io",
+				Namespaced: true,
+			},
+			{
+				Kind:       "Role",
+				Name:       "roles",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
 				Version:    "rbac.authorization.k8s.io",
 				Namespaced: true,
 			},
@@ -442,6 +649,51 @@ var v121ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "storage.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "CSIDriver",
+				Name:       "csidrivers",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "storage.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "CSINode",
+				Name:       "csinodes",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "storage.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "CSIStorageCapacity",
+				Name:       "csistoragecapacities",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "storage.k8s.io",
+				Namespaced: true,
+			},
+			{
+				Kind:       "StorageClass",
+				Name:       "storageclasses",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "storage.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "VolumeAttachment",
+				Name:       "volumeattachments",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "storage.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
 		GroupVersion: "admissionregistration.k8s.io/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -463,6 +715,27 @@ var v121ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "admissionregistration.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "MutatingWebhookConfiguration",
+				Name:       "mutatingwebhookconfigurations",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "admissionregistration.k8s.io",
+				Namespaced: false,
+			},
+			{
+				Kind:       "ValidatingWebhookConfiguration",
+				Name:       "validatingwebhookconfigurations",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "admissionregistration.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
 		GroupVersion: "apiextensions.k8s.io/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -470,6 +743,19 @@ var v121ClusterResources = []*metav1.APIResourceList{
 				Name:       "customresourcedefinitions",
 				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
 				Group:      "v1",
+				Version:    "apiextensions.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
+		GroupVersion: "apiextensions.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "CustomResourceDefinition",
+				Name:       "customresourcedefinitions",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
 				Version:    "apiextensions.k8s.io",
 				Namespaced: false,
 			},
@@ -489,6 +775,19 @@ var v121ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "scheduling.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "PriorityClass",
+				Name:       "priorityclasses",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "scheduling.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
 		GroupVersion: "coordination.k8s.io/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -496,6 +795,19 @@ var v121ClusterResources = []*metav1.APIResourceList{
 				Name:       "leases",
 				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
 				Group:      "v1",
+				Version:    "coordination.k8s.io",
+				Namespaced: true,
+			},
+		},
+	},
+	{
+		GroupVersion: "coordination.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "Lease",
+				Name:       "leases",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
 				Version:    "coordination.k8s.io",
 				Namespaced: true,
 			},
@@ -515,6 +827,19 @@ var v121ClusterResources = []*metav1.APIResourceList{
 		},
 	},
 	{
+		GroupVersion: "node.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "RuntimeClass",
+				Name:       "runtimeclasses",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
+				Version:    "node.k8s.io",
+				Namespaced: false,
+			},
+		},
+	},
+	{
 		GroupVersion: "discovery.k8s.io/v1",
 		APIResources: []metav1.APIResource{
 			{
@@ -522,6 +847,19 @@ var v121ClusterResources = []*metav1.APIResourceList{
 				Name:       "endpointslices",
 				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
 				Group:      "v1",
+				Version:    "discovery.k8s.io",
+				Namespaced: true,
+			},
+		},
+	},
+	{
+		GroupVersion: "discovery.k8s.io/v1beta1",
+		APIResources: []metav1.APIResource{
+			{
+				Kind:       "EndpointSlice",
+				Name:       "endpointslices",
+				Verbs:      metav1.Verbs{"create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"},
+				Group:      "v1beta1",
 				Version:    "discovery.k8s.io",
 				Namespaced: true,
 			},
@@ -552,8 +890,32 @@ var v121ClusterResources = []*metav1.APIResourceList{
 		GroupVersion: "crd.projectcalico.org/v1",
 		APIResources: []metav1.APIResource{
 			{
-				Kind:       "BGPPeer",
-				Name:       "bgppeers",
+				Kind:       "NetworkPolicy",
+				Name:       "networkpolicies",
+				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
+				Group:      "v1",
+				Version:    "crd.projectcalico.org",
+				Namespaced: true,
+			},
+			{
+				Kind:       "BGPConfiguration",
+				Name:       "bgpconfigurations",
+				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
+				Group:      "v1",
+				Version:    "crd.projectcalico.org",
+				Namespaced: false,
+			},
+			{
+				Kind:       "FelixConfiguration",
+				Name:       "felixconfigurations",
+				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
+				Group:      "v1",
+				Version:    "crd.projectcalico.org",
+				Namespaced: false,
+			},
+			{
+				Kind:       "BlockAffinity",
+				Name:       "blockaffinities",
 				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
 				Group:      "v1",
 				Version:    "crd.projectcalico.org",
@@ -566,30 +928,6 @@ var v121ClusterResources = []*metav1.APIResourceList{
 				Group:      "v1",
 				Version:    "crd.projectcalico.org",
 				Namespaced: false,
-			},
-			{
-				Kind:       "IPPool",
-				Name:       "ippools",
-				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
-				Group:      "v1",
-				Version:    "crd.projectcalico.org",
-				Namespaced: false,
-			},
-			{
-				Kind:       "GlobalNetworkSet",
-				Name:       "globalnetworksets",
-				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
-				Group:      "v1",
-				Version:    "crd.projectcalico.org",
-				Namespaced: false,
-			},
-			{
-				Kind:       "NetworkSet",
-				Name:       "networksets",
-				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
-				Group:      "v1",
-				Version:    "crd.projectcalico.org",
-				Namespaced: true,
 			},
 			{
 				Kind:       "IPAMBlock",
@@ -608,16 +946,24 @@ var v121ClusterResources = []*metav1.APIResourceList{
 				Namespaced: false,
 			},
 			{
-				Kind:       "IPAMHandle",
-				Name:       "ipamhandles",
+				Kind:       "IPPool",
+				Name:       "ippools",
 				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
 				Group:      "v1",
 				Version:    "crd.projectcalico.org",
 				Namespaced: false,
 			},
 			{
-				Kind:       "BlockAffinity",
-				Name:       "blockaffinities",
+				Kind:       "NetworkSet",
+				Name:       "networksets",
+				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
+				Group:      "v1",
+				Version:    "crd.projectcalico.org",
+				Namespaced: true,
+			},
+			{
+				Kind:       "BGPPeer",
+				Name:       "bgppeers",
 				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
 				Group:      "v1",
 				Version:    "crd.projectcalico.org",
@@ -632,16 +978,16 @@ var v121ClusterResources = []*metav1.APIResourceList{
 				Namespaced: false,
 			},
 			{
-				Kind:       "FelixConfiguration",
-				Name:       "felixconfigurations",
+				Kind:       "IPAMHandle",
+				Name:       "ipamhandles",
 				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
 				Group:      "v1",
 				Version:    "crd.projectcalico.org",
 				Namespaced: false,
 			},
 			{
-				Kind:       "BGPConfiguration",
-				Name:       "bgpconfigurations",
+				Kind:       "GlobalNetworkSet",
+				Name:       "globalnetworksets",
 				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
 				Group:      "v1",
 				Version:    "crd.projectcalico.org",
@@ -654,14 +1000,6 @@ var v121ClusterResources = []*metav1.APIResourceList{
 				Group:      "v1",
 				Version:    "crd.projectcalico.org",
 				Namespaced: false,
-			},
-			{
-				Kind:       "NetworkPolicy",
-				Name:       "networkpolicies",
-				Verbs:      metav1.Verbs{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"},
-				Group:      "v1",
-				Version:    "crd.projectcalico.org",
-				Namespaced: true,
 			},
 		},
 	},


### PR DESCRIPTION
#### Overview

Generated all resources for k8s fake cluster from 1.16 to 1.21 

#### What this PR does / why we need it

Previously we had only preferred versions generated. It affects some clusters like 1.16
This PR has all resources generated

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

NONE