### PR TITLE
Add SpecGenerator which is compatible with ObjectPatcher

### DIFF
--- a/pkg/kube/object_patch/patch.go
+++ b/pkg/kube/object_patch/patch.go
@@ -137,6 +137,8 @@ func (o *ObjectPatcher) GenerateFromJSONAndExecuteOperations(specs []OperationSp
 			operationError = o.DeleteObjectInBackground(spec.ApiVersion, spec.Kind, spec.Namespace, spec.Name, spec.Subresource)
 		case DeleteNonCascading:
 			operationError = o.DeleteObjectNonCascading(spec.ApiVersion, spec.Kind, spec.Namespace, spec.Name, spec.Subresource)
+		case Filter:
+			operationError = o.FilterObject(spec.FilterFunc, spec.ApiVersion, spec.Kind, spec.Namespace, spec.Name, spec.Subresource)
 		case JQPatch:
 			operationError = o.JQPatchObject(spec.JQFilter, spec.ApiVersion, spec.Kind, spec.Namespace, spec.Name, spec.Subresource)
 		case MergePatch:

--- a/pkg/kube/object_patch/patch_collector.go
+++ b/pkg/kube/object_patch/patch_collector.go
@@ -7,27 +7,27 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-type specGenerator struct {
+type patchCollector struct {
 	patchOperations []OperationSpec
 }
 
-// NewSpecGenerator creates OperationSpec generator which is compatible with ObjectPatcher interface
-func NewSpecGenerator() *specGenerator {
-	return &specGenerator{
+// NewPatchCollector creates OperationSpec collector which is compatible with ObjectPatcher interface
+func NewPatchCollector() *patchCollector {
+	return &patchCollector{
 		patchOperations: make([]OperationSpec, 0),
 	}
 }
 
-func (dop *specGenerator) CreateOrUpdateObject(object *unstructured.Unstructured, subresource string) error {
+func (dop *patchCollector) CreateOrUpdateObject(object *unstructured.Unstructured, subresource string) error {
 	return dop.create(CreateOrUpdate, object, subresource)
 }
 
-func (dop *specGenerator) CreateObject(object *unstructured.Unstructured, subresource string) error {
+func (dop *patchCollector) CreateObject(object *unstructured.Unstructured, subresource string) error {
 	return dop.create(Create, object, subresource)
 }
 
 // Deprecated: use MergePatch instead
-func (dop *specGenerator) JQPatchObject(jqPatch, apiVersion, kind, namespace, name, subresource string) error {
+func (dop *patchCollector) JQPatchObject(jqPatch, apiVersion, kind, namespace, name, subresource string) error {
 	patch := OperationSpec{
 		Operation:   JQPatch,
 		ApiVersion:  apiVersion,
@@ -43,7 +43,7 @@ func (dop *specGenerator) JQPatchObject(jqPatch, apiVersion, kind, namespace, na
 	return nil
 }
 
-func (dop *specGenerator) MergePatchObject(mergePatch []byte, apiVersion, kind, namespace, name, subresource string) error {
+func (dop *patchCollector) MergePatchObject(mergePatch []byte, apiVersion, kind, namespace, name, subresource string) error {
 	var patch map[string]interface{}
 	err := json.Unmarshal(mergePatch, &patch)
 	if err != nil {
@@ -64,7 +64,7 @@ func (dop *specGenerator) MergePatchObject(mergePatch []byte, apiVersion, kind, 
 	return nil
 }
 
-func (dop *specGenerator) JSONPatchObject(jsonPatch []byte, apiVersion, kind, namespace, name, subresource string) error {
+func (dop *patchCollector) JSONPatchObject(jsonPatch []byte, apiVersion, kind, namespace, name, subresource string) error {
 	var patch []interface{}
 	err := json.Unmarshal(jsonPatch, &patch)
 	if err != nil {
@@ -85,19 +85,19 @@ func (dop *specGenerator) JSONPatchObject(jsonPatch []byte, apiVersion, kind, na
 	return nil
 }
 
-func (dop *specGenerator) DeleteObject(apiVersion, kind, namespace, name, subresource string) error {
+func (dop *patchCollector) DeleteObject(apiVersion, kind, namespace, name, subresource string) error {
 	return dop.delete(Delete, apiVersion, kind, namespace, name, subresource)
 }
 
-func (dop *specGenerator) DeleteObjectInBackground(apiVersion, kind, namespace, name, subresource string) error {
+func (dop *patchCollector) DeleteObjectInBackground(apiVersion, kind, namespace, name, subresource string) error {
 	return dop.delete(DeleteInBackground, apiVersion, kind, namespace, name, subresource)
 }
 
-func (dop *specGenerator) DeleteObjectNonCascading(apiVersion, kind, namespace, name, subresource string) error {
+func (dop *patchCollector) DeleteObjectNonCascading(apiVersion, kind, namespace, name, subresource string) error {
 	return dop.delete(DeleteNonCascading, apiVersion, kind, namespace, name, subresource)
 }
 
-func (dop *specGenerator) FilterObject(
+func (dop *patchCollector) FilterObject(
 	filterFunc func(*unstructured.Unstructured) (*unstructured.Unstructured, error),
 	apiVersion, kind, namespace, name, subresource string,
 ) error {
@@ -120,11 +120,11 @@ func (dop *specGenerator) FilterObject(
 }
 
 // Operations returns all stored operations
-func (dop *specGenerator) Operations() []OperationSpec {
+func (dop *patchCollector) Operations() []OperationSpec {
 	return dop.patchOperations
 }
 
-func (dop *specGenerator) delete(operation OperationType, apiVersion, kind, namespace, name, subresource string) error {
+func (dop *patchCollector) delete(operation OperationType, apiVersion, kind, namespace, name, subresource string) error {
 	op := OperationSpec{
 		Operation:   operation,
 		ApiVersion:  apiVersion,
@@ -139,7 +139,7 @@ func (dop *specGenerator) delete(operation OperationType, apiVersion, kind, name
 	return nil
 }
 
-func (dop *specGenerator) create(operation OperationType, object *unstructured.Unstructured, subresource string) error {
+func (dop *patchCollector) create(operation OperationType, object *unstructured.Unstructured, subresource string) error {
 	op := OperationSpec{
 		Operation:   operation,
 		ApiVersion:  object.GetAPIVersion(),

--- a/pkg/kube/object_patch/spec_generator.go
+++ b/pkg/kube/object_patch/spec_generator.go
@@ -1,0 +1,156 @@
+package object_patch
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type specGenerator struct {
+	patchOperations []OperationSpec
+}
+
+// NewSpecGenerator creates OperationSpec generator which is compatible with ObjectPatcher interface
+func NewSpecGenerator() *specGenerator {
+	return &specGenerator{
+		patchOperations: make([]OperationSpec, 0),
+	}
+}
+
+func (dop *specGenerator) CreateOrUpdateObject(object *unstructured.Unstructured, subresource string) error {
+	return dop.create(CreateOrUpdate, object, subresource)
+}
+
+func (dop *specGenerator) CreateObject(object *unstructured.Unstructured, subresource string) error {
+	return dop.create(Create, object, subresource)
+}
+
+// Deprecated: use MergePatch instead
+func (dop *specGenerator) JQPatchObject(jqPatch, apiVersion, kind, namespace, name, subresource string) error {
+	patch := OperationSpec{
+		Operation:   JQPatch,
+		ApiVersion:  apiVersion,
+		Kind:        kind,
+		Namespace:   namespace,
+		Name:        name,
+		Subresource: subresource,
+		JQFilter:    jqPatch,
+	}
+
+	dop.patchOperations = append(dop.patchOperations, patch)
+
+	return nil
+}
+
+func (dop *specGenerator) MergePatchObject(mergePatch []byte, apiVersion, kind, namespace, name, subresource string) error {
+	var patch map[string]interface{}
+	err := json.Unmarshal(mergePatch, &patch)
+	if err != nil {
+		return err
+	}
+
+	op := OperationSpec{
+		Operation:   MergePatch,
+		ApiVersion:  apiVersion,
+		Kind:        kind,
+		Namespace:   namespace,
+		Name:        name,
+		Subresource: subresource,
+		MergePatch:  patch,
+	}
+
+	dop.patchOperations = append(dop.patchOperations, op)
+	return nil
+}
+
+func (dop *specGenerator) JSONPatchObject(jsonPatch []byte, apiVersion, kind, namespace, name, subresource string) error {
+	var patch []interface{}
+	err := json.Unmarshal(jsonPatch, &patch)
+	if err != nil {
+		return err
+	}
+
+	op := OperationSpec{
+		Operation:   MergePatch,
+		ApiVersion:  apiVersion,
+		Kind:        kind,
+		Namespace:   namespace,
+		Name:        name,
+		Subresource: subresource,
+		JSONPatch:   patch,
+	}
+
+	dop.patchOperations = append(dop.patchOperations, op)
+	return nil
+}
+
+func (dop *specGenerator) DeleteObject(apiVersion, kind, namespace, name, subresource string) error {
+	return dop.delete(Delete, apiVersion, kind, namespace, name, subresource)
+}
+
+func (dop *specGenerator) DeleteObjectInBackground(apiVersion, kind, namespace, name, subresource string) error {
+	return dop.delete(DeleteInBackground, apiVersion, kind, namespace, name, subresource)
+}
+
+func (dop *specGenerator) DeleteObjectNonCascading(apiVersion, kind, namespace, name, subresource string) error {
+	return dop.delete(DeleteNonCascading, apiVersion, kind, namespace, name, subresource)
+}
+
+func (dop *specGenerator) FilterObject(
+	filterFunc func(*unstructured.Unstructured) (*unstructured.Unstructured, error),
+	apiVersion, kind, namespace, name, subresource string,
+) error {
+
+	if filterFunc == nil {
+		return fmt.Errorf("FilterFunc could not be nil")
+	}
+	op := OperationSpec{
+		Operation:   Filter,
+		ApiVersion:  apiVersion,
+		Kind:        kind,
+		Namespace:   namespace,
+		Name:        name,
+		Subresource: subresource,
+		FilterFunc:  filterFunc,
+	}
+	dop.patchOperations = append(dop.patchOperations, op)
+
+	return nil
+}
+
+// Operations returns all stored operations
+func (dop *specGenerator) Operations() []OperationSpec {
+	return dop.patchOperations
+}
+
+func (dop *specGenerator) delete(operation OperationType, apiVersion, kind, namespace, name, subresource string) error {
+	op := OperationSpec{
+		Operation:   operation,
+		ApiVersion:  apiVersion,
+		Kind:        kind,
+		Namespace:   namespace,
+		Name:        name,
+		Subresource: subresource,
+	}
+
+	dop.patchOperations = append(dop.patchOperations, op)
+
+	return nil
+}
+
+func (dop *specGenerator) create(operation OperationType, object *unstructured.Unstructured, subresource string) error {
+	op := OperationSpec{
+		Operation:   operation,
+		ApiVersion:  object.GetAPIVersion(),
+		Kind:        object.GetKind(),
+		Namespace:   object.GetNamespace(),
+		Name:        object.GetName(),
+		Subresource: subresource,
+		Object:      object.Object,
+	}
+
+	dop.patchOperations = append(dop.patchOperations, op)
+
+	return nil
+}

--- a/pkg/kube/object_patch/types.go
+++ b/pkg/kube/object_patch/types.go
@@ -16,7 +16,8 @@ type OperationSpec struct {
 	JSONPatch  []interface{}          `json:"jsonPatch,omitempty" yaml:"jsonPatch,omitempty"`
 
 	// FilterFunc makes sense only for OperationType==Filter, mutate objects in go hooks
-	FilterFunc func(*unstructured.Unstructured) (*unstructured.Unstructured, error) `json:"filterFunc,omitempty" yaml:"filterFunc,omitempty"`
+	// It's used only in go-hooks that's why it should not (and can not) be marshalled to json and yaml
+	FilterFunc func(*unstructured.Unstructured) (*unstructured.Unstructured, error) `json:"-" yaml:"-"`
 }
 
 type OperationType string

--- a/pkg/kube/object_patch/types.go
+++ b/pkg/kube/object_patch/types.go
@@ -1,5 +1,7 @@
 package object_patch
 
+import "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 type OperationSpec struct {
 	Operation   OperationType `json:"operation" yaml:"operation"`
 	ApiVersion  string        `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
@@ -12,6 +14,9 @@ type OperationSpec struct {
 	JQFilter   string                 `json:"jqFilter,omitempty" yaml:"jqFilter,omitempty"`
 	MergePatch map[string]interface{} `json:"mergePatch,omitempty" yaml:"mergePatch,omitempty"`
 	JSONPatch  []interface{}          `json:"jsonPatch,omitempty" yaml:"jsonPatch,omitempty"`
+
+	// FilterFunc makes sense only for OperationType==Filter, mutate objects in go hooks
+	FilterFunc func(*unstructured.Unstructured) (*unstructured.Unstructured, error) `json:"filterFunc,omitempty" yaml:"filterFunc,omitempty"`
 }
 
 type OperationType string
@@ -28,4 +33,6 @@ const (
 	JQPatch    OperationType = "JQPatch"
 	MergePatch OperationType = "MergePatch"
 	JSONPatch  OperationType = "JSONPatch"
+
+	Filter OperationType = "Filter"
 )

--- a/pkg/metric_storage/metric_storage.go
+++ b/pkg/metric_storage/metric_storage.go
@@ -366,6 +366,7 @@ func (m *MetricStorage) ApplyOperation(op operation.MetricOperation, commonLabel
 		m.CounterAdd(op.Name, *op.Value, labels)
 		return
 	}
+	// nolint:staticcheck
 	if op.Add != nil {
 		m.CounterAdd(op.Name, *op.Add, labels)
 		return
@@ -374,6 +375,7 @@ func (m *MetricStorage) ApplyOperation(op operation.MetricOperation, commonLabel
 		m.GaugeSet(op.Name, *op.Value, labels)
 		return
 	}
+	// nolint:staticcheck
 	if op.Set != nil {
 		m.GaugeSet(op.Name, *op.Set, labels)
 		return
@@ -398,12 +400,14 @@ func (m *MetricStorage) ApplyGroupOperations(group string, ops []operation.Metri
 		if op.Action == "add" && op.Value != nil {
 			m.GroupedVault.CounterAdd(group, op.Name, *op.Value, labels)
 		}
+		// nolint:staticcheck
 		if op.Add != nil {
 			m.GroupedVault.CounterAdd(group, op.Name, *op.Add, labels)
 		}
 		if op.Action == "set" && op.Value != nil {
 			m.GroupedVault.GaugeSet(group, op.Name, *op.Value, labels)
 		}
+		// nolint:staticcheck
 		if op.Set != nil {
 			m.GroupedVault.GaugeSet(group, op.Name, *op.Set, labels)
 		}

--- a/pkg/metric_storage/operation/operation.go
+++ b/pkg/metric_storage/operation/operation.go
@@ -12,8 +12,10 @@ import (
 )
 
 type MetricOperation struct {
-	Name    string            `json:"name"`
-	Add     *float64          `json:"add,omitempty"` // shortcut for action=add value=num
+	Name string `json:"name"`
+	// Deprecated: use Value + Action="add" instead. Add only works for parsing from file
+	Add *float64 `json:"add,omitempty"` // shortcut for action=add value=num
+	// Deprecated: use Value + Action="set" instead. Set only works for parsing from file
 	Set     *float64          `json:"set,omitempty"` // shortcut for action=set value=num
 	Value   *float64          `json:"value,omitempty"`
 	Buckets []float64         `json:"buckets,omitempty"`
@@ -23,7 +25,7 @@ type MetricOperation struct {
 }
 
 func (m MetricOperation) String() string {
-	parts := []string{}
+	parts := make([]string, 0)
 
 	if m.Group != "" {
 		parts = append(parts, "group="+m.Group)


### PR DESCRIPTION


<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Add SpecGenerator to create SpecOperations for ObjectPatcher instead on instantly executing

#### What this PR does / why we need it

Used to collect spec in go-hooks and then execute them at once
after hook has been completed. We need it for making the same behavior for shell-hooks and go-hooks 

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

NONE

```release-note

```