### PR TITLE
feat: wait for an informer cache to become synced

### DIFF
--- a/pkg/kube_events_manager/monitor.go
+++ b/pkg/kube_events_manager/monitor.go
@@ -149,7 +149,7 @@ func (m *monitor) CreateInformers() error {
 
 				for _, informer := range m.VaryingInformers[nsName] {
 					informer.WithContext(ctx)
-					go informer.Start()
+					informer.Start()
 				}
 			},
 			func(nsName string) {
@@ -268,7 +268,7 @@ func (m *monitor) Start(parentCtx context.Context) {
 
 	for _, informer := range m.ResourceInformers {
 		informer.WithContext(m.ctx)
-		go informer.Start()
+		informer.Start()
 	}
 
 	for nsName := range m.VaryingInformers {
@@ -276,13 +276,13 @@ func (m *monitor) Start(parentCtx context.Context) {
 		ctx, m.cancelForNs[nsName] = context.WithCancel(m.ctx)
 		for _, informer := range m.VaryingInformers[nsName] {
 			informer.WithContext(ctx)
-			go informer.Start()
+			informer.Start()
 		}
 	}
 
 	if m.NamespaceInformer != nil {
 		m.NamespaceInformer.WithContext(m.ctx)
-		go m.NamespaceInformer.Start()
+		m.NamespaceInformer.Start()
 	}
 }
 

--- a/pkg/kube_events_manager/namespace_informer.go
+++ b/pkg/kube_events_manager/namespace_informer.go
@@ -143,7 +143,12 @@ func (ni *namespaceInformer) Start() {
 		close(stopCh)
 	}()
 
-	ni.SharedInformer.Run(stopCh)
+	go ni.SharedInformer.Run(stopCh)
+	if ok := cache.WaitForCacheSync(stopCh, ni.SharedInformer.HasSynced); !ok {
+		ni.Monitor.LogEntry.Errorf("%s: cache is not synced for informer", ni.Monitor.Metadata.DebugName)
+	}
+
+	log.Debugf("%s: informer is ready", ni.Monitor.Metadata.DebugName)
 }
 
 func (ni *namespaceInformer) Stop() {

--- a/pkg/kube_events_manager/resource_informer.go
+++ b/pkg/kube_events_manager/resource_informer.go
@@ -449,7 +449,13 @@ func (ei *resourceInformer) Start() {
 		close(stopCh)
 	}()
 
-	ei.SharedInformer.Run(stopCh)
+	go ei.SharedInformer.Run(stopCh)
+
+	if ok := cache.WaitForCacheSync(stopCh, ei.SharedInformer.HasSynced); !ok {
+		ei.Monitor.LogEntry.Errorf("%s: cache is not synced for informer", ei.Monitor.Metadata.DebugName)
+	}
+
+	log.Debugf("%s: informer is ready", ei.Monitor.Metadata.DebugName)
 }
 
 func (ei *resourceInformer) Stop() {

--- a/test/hook/context/generator.go
+++ b/test/hook/context/generator.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/flant/kube-client/fake"
+	"github.com/sirupsen/logrus"
+
 	"github.com/flant/shell-operator/pkg/hook"
 	. "github.com/flant/shell-operator/pkg/hook/binding_context"
 	"github.com/flant/shell-operator/pkg/hook/controller"
@@ -35,6 +37,8 @@ type BindingContextController struct {
 }
 
 func NewBindingContextController(config string, version ...fake.ClusterVersion) (*BindingContextController, error) {
+	logrus.SetLevel(logrus.ErrorLevel)
+
 	k8sVersion := fake.ClusterVersionV119
 	if len(version) > 0 {
 		k8sVersion = version[0]
@@ -110,7 +114,6 @@ func (b *BindingContextController) Run(initialState string) (GeneratedBindingCon
 
 	b.HookCtrl.UnlockKubernetesEvents()
 
-	<-time.After(time.Millisecond) // tick to trigger informers
 	return cc.CombinedAndUpdated(b.HookCtrl)
 }
 
@@ -143,7 +146,7 @@ func (b *BindingContextController) ChangeState(newState ...string) (GeneratedBin
 }
 
 func (b *BindingContextController) ChangeStateAndWaitForBindingContexts(desiredQuantity int, newState string) (GeneratedBindingContexts, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	cc := NewContextCombiner()

--- a/test/hook/context/generator_test.go
+++ b/test/hook/context/generator_test.go
@@ -56,7 +56,7 @@ metadata:
 	g.Expect(parsedBindingContexts[0].Snapshots["selected_pods"]).To(HaveLen(2))
 
 	// Object added
-	contexts, err = c.ChangeState(`
+	contexts, err = c.ChangeStateAndWaitForBindingContexts(1, `
 ---
 apiVersion: v1
 kind: Pod
@@ -82,7 +82,7 @@ spec:
 	g.Expect(parsedBindingContexts[0].Snapshots["selected_pods"]).To(HaveLen(3))
 
 	// Object modified
-	contexts, err = c.ChangeState(`
+	contexts, err = c.ChangeStateAndWaitForBindingContexts(1, `
 ---
 apiVersion: v1
 kind: Pod
@@ -109,7 +109,7 @@ spec:
 	g.Expect(parsedBindingContexts[0].Snapshots["selected_pods"]).To(HaveLen(3))
 
 	// Object deleted
-	contexts, err = c.ChangeState(`
+	contexts, err = c.ChangeStateAndWaitForBindingContexts(1, `
 ---
 apiVersion: v1
 kind: Pod
@@ -162,7 +162,7 @@ kubernetes:
 	g.Expect(bindingContexts.Rendered).To(ContainSubstring("Synchronization"))
 
 	// Event phase
-	bindingContexts, err = c.ChangeState(`
+	bindingContexts, err = c.ChangeStateAndWaitForBindingContexts(2, `
 apiVersion: my.crd.io/v1alpha1
 kind: MyResource
 metadata:
@@ -399,7 +399,7 @@ metadata:
 	g.Expect(parsedBindingContexts[0].Snapshots["selected_pods"]).To(HaveLen(2))
 
 	// Object added
-	contexts, err = c.ChangeState(`
+	contexts, err = c.ChangeStateAndWaitForBindingContexts(1, `
 ---
 apiVersion: v1
 kind: Pod
@@ -425,7 +425,7 @@ spec:
 	g.Expect(parsedBindingContexts[0].Snapshots["selected_pods"]).To(HaveLen(3))
 
 	// Object modified
-	contexts, err = c.ChangeState(`
+	contexts, err = c.ChangeStateAndWaitForBindingContexts(1, `
 ---
 apiVersion: v1
 kind: Pod
@@ -452,7 +452,7 @@ spec:
 	g.Expect(parsedBindingContexts[0].Snapshots["selected_pods"]).To(HaveLen(3))
 
 	// Object deleted
-	contexts, err = c.ChangeState(`
+	contexts, err = c.ChangeStateAndWaitForBindingContexts(1, `
 ---
 apiVersion: v1
 kind: Pod


### PR DESCRIPTION
Signed-off-by: m.nabokikh <maksim.nabokikh@flant.com>

#### Overview

Wait for the informers cache after the start.


#### What this PR does / why we need it

It fixes flaky tests.

#### Special notes for your reviewer


#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```