### PR TITLE
fix: always return non 'already exists' error for Create operation

### DIFF
--- a/test/utils/shell-operator.go
+++ b/test/utils/shell-operator.go
@@ -21,8 +21,8 @@ type ShellOperatorOptions struct {
 	KubeConfig string
 }
 
-func DefaultShellOperatorOptions(currentDir string, configPath string) ShellOperatorOptions {
-	return ShellOperatorOptions{
+func DefaultShellOperatorOptions(currentDir string, configPath string) *ShellOperatorOptions {
+	return &ShellOperatorOptions{
 		CurrentDir: currentDir,
 		BinPath:    GetShellOperatorPath(),
 		Args:       []string{"start"},
@@ -31,7 +31,7 @@ func DefaultShellOperatorOptions(currentDir string, configPath string) ShellOper
 	}
 }
 
-func (o ShellOperatorOptions) Merge(opts ShellOperatorOptions) ShellOperatorOptions {
+func (o *ShellOperatorOptions) Merge(opts *ShellOperatorOptions) *ShellOperatorOptions {
 	res := o
 	if opts.CurrentDir != "" {
 		o.CurrentDir = opts.CurrentDir
@@ -57,7 +57,7 @@ func (o ShellOperatorOptions) Merge(opts ShellOperatorOptions) ShellOperatorOpti
 	return res
 }
 
-func ExecShellOperator(operatorOpts ShellOperatorOptions, opts CommandOptions) error {
+func ExecShellOperator(operatorOpts *ShellOperatorOptions, opts CommandOptions) error {
 	if operatorOpts.BinPath == "" {
 		operatorOpts.BinPath = GetShellOperatorPath()
 	}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Fix logic behind `*IfExists` options of Create operation.
<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

Return non 'already exists' error from a `Create` call if `ignoreIfExists` or `updateIfExists` is set.

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```