### PR TITLE
Add initial delay for cron jobs

### DIFF
--- a/HOOKS.md
+++ b/HOOKS.md
@@ -124,6 +124,12 @@ schedule:
   crontab: "* * * * *"
   allowFailure: true|false
   group: "pods"
+
+- name: "every minute with first run delay"
+  crontab: "* * * * *"
+  allowFailure: true|false
+  group: "pods"
+  firstRunDelay: "5m"
   ...
 ```
 
@@ -132,6 +138,8 @@ schedule:
 - `name` — is an optional identifier. It is used to distinguish between multiple schedules during runtime. For more information see [binding context](#binding-context).
 
 - `crontab` – is a mandatory schedule with a regular crontab syntax with 5 fields. 6 fields style crontab also supported, for more information see [documentation on robfig/cron.v2 library](https://godoc.org/gopkg.in/robfig/cron.v2).
+- 
+- `firstRunDelay` – pause before first run hook. In golang time.Duration format (`1s`, `5m`, `1h`).
 
 - `allowFailure` — if ‘true’, Shell-operator skips the hook execution errors. If ‘false’ or the parameter is not set, the hook is restarted after a 5 seconds delay in case of an error.
 

--- a/examples/103-schedule/hooks/crontab-7-initial-delay.sh
+++ b/examples/103-schedule/hooks/crontab-7-initial-delay.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+if [[ $1 == "--config" ]] ; then
+  cat <<EOF
+{
+  "configVersion":"v1",
+  "schedule": [
+    {
+      "name": "every 10 sec with initial delay 10 sec",
+      "crontab": "*/10 * * * * *",
+      "firstRunDelay": "10s"
+    },
+  ]
+}
+EOF
+else
+  binding=$(cat $BINDING_CONTEXT_PATH)
+  echo "Message from 'schedule' hook with 7 fields crontab: $binding"
+fi

--- a/pkg/hook/config/config_v1.go
+++ b/pkg/hook/config/config_v1.go
@@ -33,12 +33,13 @@ type HookConfigV1 struct {
 
 // Schedule configuration
 type ScheduleConfigV1 struct {
-	Name                 string   `json:"name"`
-	Crontab              string   `json:"crontab"`
-	AllowFailure         bool     `json:"allowFailure"`
-	IncludeSnapshotsFrom []string `json:"includeSnapshotsFrom"`
-	Queue                string   `json:"queue"`
-	Group                string   `json:"group,omitempty"`
+	Name                 string        `json:"name"`
+	Crontab              string        `json:"crontab"`
+	FirstRunDelay        time.Duration `json:"firstRunDelay,omitempty"`
+	AllowFailure         bool          `json:"allowFailure"`
+	IncludeSnapshotsFrom []string      `json:"includeSnapshotsFrom"`
+	Queue                string        `json:"queue"`
+	Group                string        `json:"group,omitempty"`
 }
 
 // version 1 of kubernetes event configuration
@@ -305,8 +306,9 @@ func (cv1 *HookConfigV1) ConvertSchedule(schV1 ScheduleConfigV1) (ScheduleConfig
 
 	res.AllowFailure = schV1.AllowFailure
 	res.ScheduleEntry = ScheduleEntry{
-		Crontab: schV1.Crontab,
-		Id:      ScheduleID(),
+		Crontab:       schV1.Crontab,
+		Id:            ScheduleID(),
+		FirstRunDelay: schV1.FirstRunDelay,
 	}
 	res.IncludeSnapshotsFrom = schV1.IncludeSnapshotsFrom
 

--- a/pkg/schedule_manager/job.go
+++ b/pkg/schedule_manager/job.go
@@ -1,0 +1,60 @@
+package schedule_manager
+
+import (
+	"time"
+
+	. "github.com/flant/shell-operator/pkg/schedule_manager/types"
+
+	"github.com/sirupsen/logrus"
+	"gopkg.in/robfig/cron.v2"
+)
+
+// Schedule describes a job's duty cycle.
+type scheduleWithInitDelay struct {
+	initDelay     time.Duration
+	firstSchedule bool
+	scheduler     cron.Schedule
+}
+
+func (s *scheduleWithInitDelay) Next(cur time.Time) time.Time {
+	next := s.scheduler.Next(cur)
+	if !s.firstSchedule {
+		next = next.Add(s.initDelay)
+		s.firstSchedule = true
+	}
+
+	return next
+}
+
+type job struct {
+	scheduleCh chan string
+	entry      ScheduleEntry
+	logEntry   *logrus.Entry
+}
+
+func (j *job) Run() {
+	j.logEntry.Debugf("fire schedule event for entry '%s'", j.entry.Crontab)
+	j.scheduleCh <- j.entry.Crontab
+}
+
+func scheduleJob(cronManager *cron.Cron, entry ScheduleEntry, scheduleCh chan string) (cron.EntryID, error) {
+	logEntry := logrus.WithField("operator.component", "scheduleManager")
+	// The error can occur in case of bad format of crontab string.
+	// All crontab strings should be validated before add.
+	specSchedule, _ := cron.Parse(entry.Crontab)
+
+	schedule := &scheduleWithInitDelay{
+		initDelay: entry.InitialDelay,
+		scheduler: specSchedule,
+	}
+
+	j := &job{
+		scheduleCh: scheduleCh,
+		entry:      entry,
+		logEntry:   logEntry,
+	}
+
+	logEntry.Debugf("entry '%s' added", entry.Crontab)
+
+	return cronManager.Schedule(schedule, j), nil
+}

--- a/pkg/schedule_manager/schedule_manager.go
+++ b/pkg/schedule_manager/schedule_manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	. "github.com/flant/shell-operator/pkg/schedule_manager/types"
+
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/robfig/cron.v2"
 )
@@ -55,20 +56,11 @@ func (sm *scheduleManager) Stop() {
 // Crontab string should be validated with cron.Parse
 // function before pass to Add.
 func (sm *scheduleManager) Add(newEntry ScheduleEntry) {
-	logEntry := log.WithField("operator.component", "scheduleManager")
-
 	cronEntry, hasCronEntry := sm.Entries[newEntry.Crontab]
 
 	// If no entry, then add new scheduled function and save CronEntry.
 	if !hasCronEntry {
-		// The error can occur in case of bad format of crontab string.
-		// All crontab strings should be validated before add.
-		entryId, _ := sm.cron.AddFunc(newEntry.Crontab, func() {
-			logEntry.Debugf("fire schedule event for entry '%s'", newEntry.Crontab)
-			sm.ScheduleCh <- newEntry.Crontab
-		})
-
-		logEntry.Debugf("entry '%s' added", newEntry.Crontab)
+		entryId, _ := scheduleJob(sm.cron, newEntry, sm.ScheduleCh)
 
 		sm.Entries[newEntry.Crontab] = CronEntry{
 			EntryID: entryId,

--- a/pkg/schedule_manager/types/types.go
+++ b/pkg/schedule_manager/types/types.go
@@ -5,7 +5,7 @@ import "time"
 // ScheduleEntry is used to be able Add one crontab multiple
 // times and independently Remove individual crontabs.
 type ScheduleEntry struct {
-	Crontab      string
-	Id           string
-	InitialDelay time.Duration // delay before first schedule
+	Crontab       string
+	Id            string
+	FirstRunDelay time.Duration // delay before first schedule
 }

--- a/pkg/schedule_manager/types/types.go
+++ b/pkg/schedule_manager/types/types.go
@@ -1,8 +1,11 @@
 package types
 
+import "time"
+
 // ScheduleEntry is used to be able Add one crontab multiple
 // times and independently Remove individual crontabs.
 type ScheduleEntry struct {
-	Crontab string
-	Id      string
+	Crontab      string
+	Id           string
+	InitialDelay time.Duration // delay before first schedule
 }


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Add `firstRunDelay` setting for crontab hooks.
This setting add delay before first schedule hook.

#### What this PR does / why we need it

In [addon-operator](https://github.com/flant/addon-operator), we want run crontab tasks after first converge.
For prevent running multiple hooks in one time, we need to add delay for first run.
We added `firstRunDelay` setting for crontab hooks.

#### Special notes for your reviewer
Maybe, we can choice better name for setting?

#### Does this PR introduce a user-facing change?
Yes. User can add first run hook delay with `firstRunDelay` setting.
This setting is optional.

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```