### PR TITLE
enable FullTimestamp output for logrus color mode

### DIFF
--- a/pkg/app/log.go
+++ b/pkg/app/log.go
@@ -35,7 +35,7 @@ func SetupLogging() {
 	case "text":
 		log.SetFormatter(&log.TextFormatter{DisableTimestamp: LogNoTime, DisableColors: true})
 	case "color":
-		log.SetFormatter(&log.TextFormatter{DisableTimestamp: LogNoTime, ForceColors: true})
+		log.SetFormatter(&log.TextFormatter{DisableTimestamp: LogNoTime, ForceColors: true, FullTimestamp: true})
 	default:
 		log.SetFormatter(&log.JSONFormatter{DisableTimestamp: LogNoTime})
 	}


### PR DESCRIPTION
#### Overview

- fix logrus output timestamp format (full timestamp)

#### What this PR does / why we need it

LOG_TYPE=color now prints full time.

Before:
<img width="573" src="https://user-images.githubusercontent.com/1055474/153254408-281dfe34-025e-4273-bb91-fe7f67f47321.png">


After:
<img width="573" src="https://user-images.githubusercontent.com/1055474/153254466-2a324d3b-8b4e-4709-abbc-681979addd86.png">

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?