### PR TITLE
Set defaults for creating rate limiter if hook execution settings is empty but not nil.

### DIFF
--- a/pkg/hook/hook.go
+++ b/pkg/hook/hook.go
@@ -292,8 +292,12 @@ func CreateRateLimiter(cfg *config.HookConfig) *rate.Limiter {
 	limit := rate.Inf // no rate limit by default
 	burst := 1        // no more then 1 event at time
 	if cfg.Settings != nil {
-		limit = rate.Every(cfg.Settings.ExecutionMinInterval)
-		burst = cfg.Settings.ExecutionBurst
+		if cfg.Settings.ExecutionMinInterval != 0 {
+			limit = rate.Every(cfg.Settings.ExecutionMinInterval)
+		}
+		if cfg.Settings.ExecutionBurst != 0 {
+			burst = cfg.Settings.ExecutionBurst
+		}
 	}
 	return rate.NewLimiter(limit, burst)
 }

--- a/pkg/hook/hook_test.go
+++ b/pkg/hook/hook_test.go
@@ -57,16 +57,16 @@ func Test_CreateLimiter(t *testing.T) {
 		},
 
 		{
-			title: "Burst is zero limit is none zero: should return limiter with zero burst and converted interval",
+			title: "Burst is zero, limit is non-zero: should return limiter with zero burst and converted interval",
 			limit: rate.Limit(1 / 20.0),
-			burst: 0,
+			burst: defaultBurst,
 			settings: &Settings{
 				ExecutionMinInterval: 20 * time.Second,
 			},
 		},
 
 		{
-			title: "Burst is none zero limit is zero: should return limiter with default limiter and passed burst",
+			title: "Burst is non-zero, limit is zero: should return limiter with default limiter and passed burst",
 			limit: defaultLimit,
 			burst: 3,
 			settings: &Settings{
@@ -75,7 +75,7 @@ func Test_CreateLimiter(t *testing.T) {
 		},
 
 		{
-			title: "All settings passed: should run limiter with all passed burst and converted interval",
+			title: "Burst and limit are passed: should run limiter with passed burst and converted interval",
 			limit: rate.Limit(1.0 / 30),
 			burst: 3,
 			settings: &Settings{
@@ -93,8 +93,8 @@ func Test_CreateLimiter(t *testing.T) {
 
 			l := CreateRateLimiter(cfg)
 
-			g.Expect(l.Burst(), c.burst)
-			g.Expect(l.Limit(), c.limit)
+			g.Expect(l.Burst()).To(Equal(c.burst))
+			g.Expect(l.Limit()).To(Equal(c.limit))
 		})
 	}
 }


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

<!-- Describe your changes briefly here. -->

Set defaults for creating rate limiter if hook execution settings is empty but not nil.

In Addon-operator now has special flag for enable schedule  go-hook before first converge.
This flag was added into [HookConfigSettings](https://github.com/flant/addon-operator/pull/300/files#diff-afc24ed4293764eb4427af841e54f863dabd28d1dbb9d1772423dd83d8c5a69cR162) 
If this struct is not nil, its fields will be copied into Shell-operator hook Settings struct. Depend on this struct shell operator create rate limiter and if this settings struct is nil create rate limiter with defaults. We need to check that empty values in settings  (when struct was created but fields was not filled) will create rate limiter with default settings and if need - fix it.

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```