### PR TITLE
fix: update versions to address CVE-2022-23806

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM --platform=${TARGETPLATFORM:-linux/amd64} flant/jq:b6be13d5-musl as libjq
 
 # Go builder.
-FROM --platform=${TARGETPLATFORM:-linux/amd64} golang:1.16-alpine3.14 AS builder
+FROM --platform=${TARGETPLATFORM:-linux/amd64} golang:1.16-alpine3.15 AS builder
 
 ARG appVersion=latest
 RUN apk --no-cache add git ca-certificates gcc musl-dev libc-dev
@@ -24,12 +24,12 @@ RUN CGO_ENABLED=1 \
              ./cmd/shell-operator
 
 # Final image
-FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine:3.14
+FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine:3.15
 ARG TARGETPLATFORM
 RUN apk --no-cache add ca-certificates bash sed tini && \
     kubectlArch=$(echo ${TARGETPLATFORM:-linux/amd64} | sed 's/\/v7//') && \
     echo "Download kubectl for ${kubectlArch}" && \
-    wget https://storage.googleapis.com/kubernetes-release/release/v1.21.8/bin/${kubectlArch}/kubectl -O /bin/kubectl && \
+    wget https://storage.googleapis.com/kubernetes-release/release/v1.21.10/bin/${kubectlArch}/kubectl -O /bin/kubectl && \
     chmod +x /bin/kubectl && \
     mkdir /hooks
 ADD frameworks/shell /frameworks/shell


### PR DESCRIPTION


<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

- kubectl 1.21.8 built with vulnerable Go 1.16.12
- Use kubectl 1.21.10 built with Go 1.16.14.
- Update alpine to 3.15.

```
Binaries from v1.0.8:
$  kubectl version
Client Version: version.Info{... GitVersion:"v1.21.8", ... GoVersion:"go1.16.12" ...}
$  go version shell-operator
shell-operator: go1.16.15
```

<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

Fix #367

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```