### PR TITLE
fix: update alpine to address CVE-2022-28391

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN CGO_ENABLED=1 \
              ./cmd/shell-operator
 
 # Final image
-FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine:3.15
+FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine:3.15.4
 ARG TARGETPLATFORM
 RUN apk --no-cache add ca-certificates bash sed tini && \
     kubectlArch=$(echo ${TARGETPLATFORM:-linux/amd64} | sed 's/\/v7//') && \


### PR DESCRIPTION
#### Overview

change the base image from alpine:3.15 to alpine:3.15.4

#### What this PR does / why we need it

to fix the https://github.com/flant/shell-operator/issues/387

#### Special notes for your reviewer

Scan the image with harbor . The fix is worked.

![企业微信截图_16521629085287](https://user-images.githubusercontent.com/1469319/167559726-2ef7481c-d471-43ca-a279-c4072705b1a6.png)

#### Does this PR introduce a user-facing change?

