### PR TITLE
fix: restore separate metric storage after #388

### DIFF
--- a/pkg/shell-operator/bootstrap.go
+++ b/pkg/shell-operator/bootstrap.go
@@ -115,25 +115,25 @@ func AssembleCommonOperator(op *ShellOperator) (err error) {
 		return fmt.Errorf("start HTTP server: %s", err)
 	}
 
-	metricStorage := DefaultMetricStorage(op.ctx)
-	op.MetricStorage = metricStorage
+	op.MetricStorage = DefaultMetricStorage(op.ctx)
 
-	hookMetricStorage, err := SetupHookMetricStorageAndServer(op.ctx)
+	op.HookMetricStorage, err = SetupHookMetricStorageAndServer(op.ctx)
 	if err != nil {
 		return fmt.Errorf("start HTTP server for hook metrics: %s", err)
 	}
-	if hookMetricStorage == nil {
+	// Set to common metric storage if separate port is not set.
+	if op.HookMetricStorage == nil {
 		op.HookMetricStorage = op.MetricStorage
 	}
 
 	// 'main' Kubernetes client.
-	op.KubeClient, err = InitDefaultMainKubeClient(metricStorage)
+	op.KubeClient, err = InitDefaultMainKubeClient(op.MetricStorage)
 	if err != nil {
 		return err
 	}
 
 	// ObjectPatcher with a separate Kubernetes client.
-	op.ObjectPatcher, err = InitDefaultObjectPatcher(metricStorage)
+	op.ObjectPatcher, err = InitDefaultObjectPatcher(op.MetricStorage)
 	if err != nil {
 		return err
 	}

--- a/pkg/shell-operator/operator.go
+++ b/pkg/shell-operator/operator.go
@@ -870,28 +870,6 @@ func (op *ShellOperator) RunMetrics() {
 	}()
 }
 
-//func (op *ShellOperator) SetupHookMetricStorageAndServer() error {
-//	if op.HookMetricStorage != nil {
-//		return nil
-//	}
-//	if app.HookMetricsListenPort == "" || app.HookMetricsListenPort == app.ListenPort {
-//		// register default prom handler in DefaultServeMux
-//		op.HookMetricStorage = op.MetricStorage
-//	} else {
-//		// create new metric storage for hooks
-//		op.InitHookMetricStorage()
-//		// Create new ServeMux, serve on custom port
-//		mux := http.NewServeMux()
-//		err := op.StartHttpServer(app.ListenAddress, app.HookMetricsListenPort, mux)
-//		if err != nil {
-//			return err
-//		}
-//		// register scrape handler
-//		mux.Handle("/metrics", op.HookMetricStorage.Handler())
-//	}
-//	return nil
-//}
-
 // Shutdown pause kubernetes events handling and stop queues. Wait for queues to stop.
 func (op *ShellOperator) Shutdown() {
 	op.ScheduleManager.Stop()


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Restore separate metrics storage for hooks.
<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

No metrics from hooks when separate port for hook metrics is in use after applying #388.
<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```