### PR TITLE
fix: restore exponential backoff after #388

### DIFF
--- a/pkg/task/queue/task_queue.go
+++ b/pkg/task/queue/task_queue.go
@@ -532,11 +532,6 @@ func (q *TaskQueue) waitForTask(sleepDelay time.Duration) task.Task {
 			}
 		}
 
-		// Emulate bug
-		if !q.IsEmpty() {
-			return q.GetFirst()
-		}
-
 		// Break the for-loop to see if the head task can be returned.
 		if checkTask {
 			if q.IsEmpty() {

--- a/pkg/task/queue/task_queue_test.go
+++ b/pkg/task/queue/task_queue_test.go
@@ -136,7 +136,7 @@ func Test_ExponentialBackoff(t *testing.T) {
 	prev := failureCounts[0]
 	for i := 1; i < len(failureCounts); i++ {
 		cur := failureCounts[i]
-		g.Expect(cur > prev).Should(BeTrue(), "TaskHandler should receive task wth growing FailureCount. Got %d after %d", cur, prev)
+		g.Expect(cur > prev).Should(BeTrue(), "TaskHandler should receive task with growing FailureCount. Got %d after %d", cur, prev)
 	}
 
 	// Expect mean delay is greater than mocked delay.

--- a/pkg/task/queue/task_queue_test.go
+++ b/pkg/task/queue/task_queue_test.go
@@ -2,8 +2,10 @@ package queue
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 
@@ -71,4 +73,91 @@ func Test_TasksQueue_Remove(t *testing.T) {
 		ContainSubstring("task_01"),
 		ContainSubstring("task_03"),
 	))
+}
+
+func Test_ExponentialBackoff(t *testing.T) {
+	g := NewWithT(t)
+	// Init and prefill queue.
+	q := NewTasksQueue()
+	q.WithContext(context.TODO())
+	q.WithName("test-queue")
+	// Since we don't want the test to run for too long, we don't
+	// want to use lengthy times.
+	q.WaitLoopCheckInterval = 5 * time.Millisecond // default is 125ms
+	q.DelayOnQueueIsEmpty = 5 * time.Millisecond   // default is 250ms
+	q.DelayOnRepeat = 5 * time.Millisecond         // default is 25ms
+	// Add one task.
+	Task := &task.BaseTask{Id: "First one"}
+	q.AddFirst(Task)
+
+	// Set handler to fail 10 times and catch timestamps for each task execution.
+	runsAt := make([]time.Time, 0)
+	failureCounts := make([]int, 0)
+	const fails = 10
+	failsCount := fails
+	queueStopCh := make(chan struct{}, 1)
+	q.WithHandler(func(t task.Task) (res TaskResult) {
+		runsAt = append(runsAt, time.Now())
+		failureCounts = append(failureCounts, t.GetFailureCount())
+		if failsCount > 0 {
+			res.Status = Fail
+			failsCount--
+			return
+		}
+		res.Status = Success
+		res.AfterHandle = func() {
+			close(queueStopCh)
+		}
+		return
+	})
+
+	// Set exponential backoff to constant delay just to wait more than DelayOnQueueIsEmpty.
+	// It is a test of delaying between task runs, not a test of exponential distribution.
+	mockExponentialDelay := 30 * time.Millisecond
+	q.ExponentialBackoffFn = func(failureCount int) time.Duration {
+		return mockExponentialDelay
+	}
+
+	q.Start()
+
+	// Expect TaskHandler returns Success result.
+	g.Eventually(func() bool {
+		select {
+		case <-queueStopCh:
+			return true
+		default:
+			return false
+		}
+	}, "5s", "20ms").Should(BeTrue(), "Should handle first task in queue successfully")
+
+	// Expect TaskHandler called 'fails' times.
+	g.Expect(Task.GetFailureCount()).Should(Equal(fails), "task should fail %d times.", fails)
+
+	prev := failureCounts[0]
+	for i := 1; i < len(failureCounts); i++ {
+		cur := failureCounts[i]
+		g.Expect(cur > prev).Should(BeTrue(), "TaskHandler should receive task wth growing FailureCount. Got %d after %d", cur, prev)
+	}
+
+	// Expect mean delay is greater than mocked delay.
+	mean, _ := calculateMeanDelay(runsAt)
+	g.Expect(mean > mockExponentialDelay).Should(BeTrue(),
+		"mean delay of %d fails should be more than %s, got %s. Check exponential delaying not broken in Start or waitForTask.",
+		fails, mockExponentialDelay.String(), mean.Truncate(100*time.Microsecond).String())
+
+}
+
+func calculateMeanDelay(in []time.Time) (mean time.Duration, deltas []int64) {
+	var sum int64
+
+	// Calculate deltas from timestamps.
+	prev := in[0].UnixNano()
+	for i := 1; i < len(in); i++ {
+		delta := in[i].UnixNano() - prev
+		prev = in[i].UnixNano()
+		deltas = append(deltas, delta)
+		sum += delta
+	}
+	mean = time.Duration(sum / int64(len(deltas)))
+	return
 }

--- a/pkg/task/queue/task_queue_test.go
+++ b/pkg/task/queue/task_queue_test.go
@@ -134,7 +134,7 @@ func Test_ExponentialBackoff(t *testing.T) {
 
 	// Expect mean delay is greater than mocked delay.
 	mean, _ := calculateMeanDelay(runsAt)
-	g.Expect(mean > mockExponentialDelay).Should(BeTrue(),
+	g.Expect(mean).Should(BeNumerically(">", mockExponentialDelay),
 		"mean delay of %d fails should be more than %s, got %s. Check exponential delaying not broken in Start or waitForTask.",
 		fails, mockExponentialDelay.String(), mean.Truncate(100*time.Microsecond).String())
 
@@ -224,10 +224,10 @@ func Test_CancelDelay(t *testing.T) {
 	elapsed := endedAt.Sub(startedAt).Truncate(100 * time.Microsecond)
 
 	// Expect elapsed is less than mocked delay.
-	g.Expect(elapsed > mockExponentialDelay).Should(BeTrue(),
+	g.Expect(elapsed).Should(BeNumerically(">", mockExponentialDelay),
 		"Should delay after failed task. Got delay of %s, expect more than %s. Check delay for failed task not broken in Start or waitForTask.",
 		elapsed.String(), mockExponentialDelay.String())
-	g.Expect(elapsed < 2*mockExponentialDelay).Should(BeTrue(),
+	g.Expect(elapsed).Should(BeNumerically("<", 2*mockExponentialDelay),
 		"Should stop delaying after CancelTaskDelay call. Got delay of %s, expect less than %s. Check cancel delay not broken in Start or waitForTask.",
 		elapsed.String(), (2 * mockExponentialDelay).String())
 }


### PR DESCRIPTION

<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Restore exponential backoff for delayed between  failed hooks restarts.
<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

Failed hook restarts every second after merging #388.
<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```