### PR TITLE
fix: prevent map write race for cached snapshot update

### DIFF
--- a/pkg/hook/controller/hook_controller.go
+++ b/pkg/hook/controller/hook_controller.go
@@ -321,7 +321,7 @@ func (hc *hookController) getIncludeSnapshotsFrom(bindingType BindingType, bindi
 
 // UpdateSnapshots ensures fresh consistent snapshots for combined binding contexts.
 //
-// It uses caching to retrieve snapshot for particular binding name only once..
+// It uses caching to retrieve snapshots for a particular binding name only once.
 // This caching is important for Synchronization and self-includes:
 // Combined "Synchronization" binging contexts or "Synchronization"
 // with self-inclusion may require several calls to Snapshot*() methods, but objects

--- a/pkg/hook/controller/hook_controller_test.go
+++ b/pkg/hook/controller/hook_controller_test.go
@@ -1,7 +1,82 @@
 package controller
 
-import "testing"
+import (
+	"context"
+	"testing"
 
-func Test_KubernetesValidating(t *testing.T) {
+	. "github.com/onsi/gomega"
 
+	"github.com/flant/kube-client/fake"
+	"github.com/flant/shell-operator/pkg/hook/binding_context"
+	"github.com/flant/shell-operator/pkg/hook/config"
+	"github.com/flant/shell-operator/pkg/hook/types"
+	"github.com/flant/shell-operator/pkg/kube_events_manager"
+	types2 "github.com/flant/shell-operator/pkg/kube_events_manager/types"
+)
+
+// Test updating snapshots for combined contexts.
+func Test_UpdateSnapshots(t *testing.T) {
+	g := NewWithT(t)
+
+	fc := fake.NewFakeCluster(fake.ClusterVersionV121)
+	mgr := kube_events_manager.NewKubeEventsManager()
+	mgr.WithContext(context.Background())
+	mgr.WithKubeClient(fc.Client)
+
+	testHookConfig := `
+configVersion: v1
+kubernetes:
+- name: binding_1
+  apiVersion: v1
+  kind: Pod
+  executeHookOnEvent: ["Added"]
+  includeSnapshotsFrom: ["binding_1"]
+- name: binding_2
+  apiVersion: v1
+  kind: Pod
+  executeHookOnEvent: ["Added"]
+  includeSnapshotsFrom: ["binding_1", "binding_2"]
+- name: binding_3
+  apiVersion: v1
+  kind: Pod
+  executeHookOnEvent: ["Added"]
+  includeSnapshotsFrom: ["binding_2", "binding_3", "binding_1"]
+`
+	// Use HookConfig as importing Hook lead to import cycle.
+	testCfg := &config.HookConfig{}
+	err := testCfg.LoadAndValidate([]byte(testHookConfig))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	hc := NewHookController()
+	hc.InitKubernetesBindings(testCfg.OnKubernetesEvents, mgr)
+	hc.EnableScheduleBindings()
+
+	// Test case: combined binding context for binding_2 and binding_3.
+	bcs := []binding_context.BindingContext{
+		{
+			Binding:    "binding_2",
+			Type:       types2.TypeEvent,
+			WatchEvent: types2.WatchEventAdded,
+		},
+		{
+			Binding:    "binding_3",
+			Type:       types2.TypeEvent,
+			WatchEvent: types2.WatchEventAdded,
+		},
+	}
+	bcs[0].Metadata.BindingType = types.OnKubernetesEvent
+	bcs[1].Metadata.BindingType = types.OnKubernetesEvent
+
+	newBcs := hc.UpdateSnapshots(bcs)
+
+	g.Expect(newBcs).To(HaveLen(len(bcs)))
+
+	bc := newBcs[0]
+	g.Expect(bc.Snapshots).Should(HaveKey("binding_1"))
+	g.Expect(bc.Snapshots).Should(HaveKey("binding_2"))
+
+	bc = newBcs[1]
+	g.Expect(bc.Snapshots).Should(HaveKey("binding_1"))
+	g.Expect(bc.Snapshots).Should(HaveKey("binding_2"))
+	g.Expect(bc.Snapshots).Should(HaveKey("binding_3"))
 }


### PR DESCRIPTION

<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Remove centralized cache in KubernetesBindingsController.
Move cache to HookController.UpdateSnapshots to make it
individual for each hook execution.

<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

Fix #386 
<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

First solution was to add Lock/Unlock on cache map, but it turns out that single map approach is a bad design.

UpdateSnapshots is called from different queues, and individual cache for each call is a better solution.

Also note, `Monitor.Snapshot()` call is synchronized.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```