### PR TITLE
fix: enable kube events for hooks with namespace.labelSelector bindings

### DIFF
--- a/pkg/kube_events_manager/monitor.go
+++ b/pkg/kube_events_manager/monitor.go
@@ -45,7 +45,8 @@ type monitor struct {
 
 	informerSyncTime time.Duration
 
-	eventCb func(KubeEvent)
+	eventCb       func(KubeEvent)
+	eventsEnabled bool
 	// Index of namespaces statically defined in monitor configuration
 	staticNamespaces map[string]bool
 
@@ -135,7 +136,7 @@ func (m *monitor) CreateInformers() error {
 		m.NamespaceInformer.WithKubeClient(m.KubeClient)
 		err := m.NamespaceInformer.CreateSharedInformer(
 			func(nsName string) {
-				// add function — check, create and run informers for Ns
+				// Added/Modified event: check, create and run informers for Ns
 				// ignore event if namespace is already has static ResourceInformers
 				if _, ok := m.staticNamespaces[nsName]; ok {
 					return
@@ -160,11 +161,13 @@ func (m *monitor) CreateInformers() error {
 				for _, informer := range m.VaryingInformers[nsName] {
 					informer.WithContext(ctx)
 					informer.Start()
-					informer.EnableKubeEventCb()
+					if m.eventsEnabled {
+						informer.EnableKubeEventCb()
+					}
 				}
 			},
 			func(nsName string) {
-				// delete function — check, stop and remove informers for Ns
+				// Delete event: check, stop and remove informers for Ns
 				logEntry.Infof("deleted ns/%s, stop dynamic ResourceInformers", nsName)
 
 				// ignore statically specified namespaces
@@ -239,6 +242,8 @@ func (m *monitor) EnableKubeEventCb() {
 			informer.EnableKubeEventCb()
 		}
 	}
+	// Enable events for future VaryingInformers.
+	m.eventsEnabled = true
 }
 
 // CreateInformersForNamespace creates informers bounded to the namespace. If no matchName is specified,

--- a/pkg/kube_events_manager/monitor.go
+++ b/pkg/kube_events_manager/monitor.go
@@ -160,10 +160,10 @@ func (m *monitor) CreateInformers() error {
 
 				for _, informer := range m.VaryingInformers[nsName] {
 					informer.WithContext(ctx)
-					informer.Start()
 					if m.eventsEnabled {
 						informer.EnableKubeEventCb()
 					}
+					informer.Start()
 				}
 			},
 			func(nsName string) {

--- a/pkg/kube_events_manager/monitor.go
+++ b/pkg/kube_events_manager/monitor.go
@@ -136,8 +136,6 @@ func (m *monitor) CreateInformers() error {
 		err := m.NamespaceInformer.CreateSharedInformer(
 			func(nsName string) {
 				// add function — check, create and run informers for Ns
-				logEntry.Infof("got ns/%s, create dynamic ResourceInformers", nsName)
-
 				// ignore event if namespace is already has static ResourceInformers
 				if _, ok := m.staticNamespaces[nsName]; ok {
 					return
@@ -147,6 +145,8 @@ func (m *monitor) CreateInformers() error {
 				if ok {
 					return
 				}
+
+				logEntry.Infof("got ns/%s, create dynamic ResourceInformers", nsName)
 
 				var err error
 				m.VaryingInformers[nsName], err = m.CreateInformersForNamespace(nsName)
@@ -160,6 +160,7 @@ func (m *monitor) CreateInformers() error {
 				for _, informer := range m.VaryingInformers[nsName] {
 					informer.WithContext(ctx)
 					informer.Start()
+					informer.EnableKubeEventCb()
 				}
 			},
 			func(nsName string) {

--- a/pkg/kube_events_manager/monitor_test.go
+++ b/pkg/kube_events_manager/monitor_test.go
@@ -1,0 +1,143 @@
+package kube_events_manager
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/flant/kube-client/fake"
+	"github.com/flant/kube-client/manifest"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/flant/shell-operator/pkg/kube_events_manager/types"
+)
+
+func Test_Monitor_should_handle_dynamic_ns_events(t *testing.T) {
+	g := NewWithT(t)
+	fc := fake.NewFakeCluster(fake.ClusterVersionV121)
+
+	// Initial namespace with ConfigMap.
+	createNsWithLabels(fc, "default", map[string]string{"test-label": ""})
+	createCM(fc, "default", testCM("default-cm-1"))
+
+	monitorCfg := &MonitorConfig{
+		ApiVersion: "v1",
+		Kind:       "ConfigMap",
+		EventTypes: []WatchEventType{WatchEventAdded, WatchEventModified, WatchEventDeleted},
+		NamespaceSelector: &NamespaceSelector{
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"test-label": "",
+				},
+			},
+		},
+	}
+
+	mon := NewMonitor()
+	mon.WithContext(context.TODO())
+	mon.WithKubeClient(fc.Client)
+	mon.WithConfig(monitorCfg)
+
+	// Catch KubeEvents from monitor.
+	type kubeEvent struct {
+		Type  KubeEventType
+		Count int
+	}
+	events := make([]kubeEvent, 0)
+	mon.WithKubeEventCb(func(ev KubeEvent) {
+		events = append(events, kubeEvent{
+			Type:  ev.Type,
+			Count: len(ev.Objects),
+		})
+	})
+
+	// Start monitor.
+	err := mon.CreateInformers()
+	g.Expect(err).ShouldNot(HaveOccurred())
+	mon.Start(context.TODO())
+
+	// Get initial snapshot.
+	snap := mon.Snapshot()
+	g.Expect(snap).Should(HaveLen(1), "Should have only one ConfigMap on start")
+	g.Expect(events).Should(HaveLen(0), "Should not call KubeEventCb until EnableKubeEventsCb")
+
+	// Simulate object creation during Synchronization phase:
+	// create new ns with matching labels and then create new ConfigMap.
+	createNsWithLabels(fc, "test-ns-1", map[string]string{"test-label": ""})
+
+	// Wait until informer appears.
+	g.Eventually(func() bool {
+		monImpl := mon.(*monitor)
+		return len(monImpl.VaryingInformers) == 2
+	}, "5s", "10ms").Should(BeTrue(), "Should create informer for new Namespace")
+
+	createCM(fc, "test-ns-1", testCM("cm-1"))
+
+	// Should update snapshot. Snapshot resets cached events.
+	g.Eventually(func() bool {
+		snap := mon.Snapshot()
+		return len(snap) == 2
+	}, "5s", "10ms").Should(BeTrue(), "Should not update snapshot until EnableKubeEventsCb")
+
+	// Create more ConfigMaps to cache some events.
+	createCM(fc, "test-ns-1", testCM("cm-2"))
+	createCM(fc, "test-ns-1", testCM("cm-3"))
+
+	g.Expect(events).Should(HaveLen(0), "Should not fire KubeEvents until EnableKubeEventsCb")
+
+	// Enable Kube events, should update snapshots now.
+	mon.EnableKubeEventCb()
+
+	// Should catch 2 events for cm-2 and cm-3.
+	g.Eventually(func() bool {
+		return len(events) == 2
+	}, "6s", "10ms").Should(BeTrue(), "Should fire cached KubeEvents after EnableKubeEventCb")
+
+	// Now simulate NS creation and objects creation after Synchronization phase.
+
+	// Create new ns with labels and cm there.
+	createNsWithLabels(fc, "test-ns-2", map[string]string{"test-label": ""})
+
+	// Wait until informer for new NS appears.
+	g.Eventually(func() bool {
+		monImpl := mon.(*monitor)
+		return len(monImpl.VaryingInformers) == 3
+	}, "5s", "10ms").Should(BeTrue(), "Should create informer for ns/test-ns-2")
+
+	createCM(fc, "test-ns-2", testCM("cm-2-1"))
+
+	// Should update snapshot.
+	g.Eventually(func() bool {
+		return len(mon.Snapshot()) == 4
+	}, "5s", "10ms").Should(BeTrue(), "Should update snapshot after Synchronization")
+
+	// Should catch event for cm/cm-2-1.
+	g.Eventually(func() bool {
+		return len(events) == 3
+	}, "5s", "10ms").Should(BeTrue(), "Should fire KubeEvent after Synchronization")
+}
+
+func createNsWithLabels(fc *fake.Cluster, name string, labels map[string]string) {
+	nsObj := &corev1.Namespace{}
+	nsObj.SetName(name)
+	nsObj.SetLabels(labels)
+	_, _ = fc.Client.CoreV1().Namespaces().Create(context.TODO(), nsObj, metav1.CreateOptions{})
+}
+
+func createCM(fc *fake.Cluster, ns string, cmYAML string) {
+	mft := manifest.MustFromYAML(cmYAML)
+	_ = fc.Create(ns, mft)
+}
+
+func testCM(name string) string {
+	return fmt.Sprintf(`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "%s"
+data:
+  foo: "bar"
+`, name)
+}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Add flag to enable KubeEvents for varying informers after Synchronization phase.

<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

See #379 and #399. This fix enables events for hooks with namespace.labelSelector.

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

"before" situation can be emulated by commenting `m.eventsEnabled = true` in monitor.go. Test will fail:

```
    monitor_test.go:119: 
        Timed out after 5.000s.
        Should fire KubeEvent after Synchronization
        Expected
            <bool>: false
        to be true
```


#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```