### PR TITLE
Use Factory for informers

### DIFF
--- a/pkg/kube_events_manager/factory.go
+++ b/pkg/kube_events_manager/factory.go
@@ -2,15 +2,23 @@ package kube_events_manager
 
 import (
 	"sync"
+	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/tools/cache"
 )
 
-var DefaultFactoryCache *FactoryCache
+var (
+	DefaultFactoryStore *FactoryStore
+	DefaultSyncTime     = 100 * time.Millisecond
+)
 
 func init() {
-	DefaultFactoryCache = NewFactoryCache()
+	DefaultFactoryStore = NewFactoryStore()
 }
 
 type FactoryIndex struct {
@@ -20,28 +28,94 @@ type FactoryIndex struct {
 	LabelSelector string
 }
 
-type FactoryCache struct {
-	mu   sync.RWMutex
-	data map[FactoryIndex]dynamicinformer.DynamicSharedInformerFactory
+type Factory struct {
+	shared dynamicinformer.DynamicSharedInformerFactory
+	score  uint64
+	stopCh chan struct{}
 }
 
-func NewFactoryCache() *FactoryCache {
-	return &FactoryCache{
-		data: make(map[FactoryIndex]dynamicinformer.DynamicSharedInformerFactory),
+type FactoryStore struct {
+	mu   sync.Mutex
+	data map[FactoryIndex]Factory
+}
+
+func NewFactoryStore() *FactoryStore {
+	return &FactoryStore{
+		data: make(map[FactoryIndex]Factory),
 	}
 }
 
-func (c *FactoryCache) Get(index FactoryIndex) dynamicinformer.DynamicSharedInformerFactory {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	f, _ := c.data[index]
-	return f
+func (c *FactoryStore) add(index FactoryIndex, f dynamicinformer.DynamicSharedInformerFactory) {
+	c.data[index] = Factory{
+		shared: f,
+		score:  uint64(1),
+		stopCh: make(chan struct{}, 1),
+	}
 }
 
-func (c *FactoryCache) Add(index FactoryIndex, f dynamicinformer.DynamicSharedInformerFactory) {
+func (c *FactoryStore) get(client dynamic.Interface, index FactoryIndex) Factory {
+	f, ok := c.data[index]
+	if ok {
+		f.score++
+		return f
+	}
+
+	// define resyncPeriod for informer
+	resyncPeriod := RandomizedResyncPeriod()
+
+	tweakListOptions := func(options *metav1.ListOptions) {
+		if index.FieldSelector != "" {
+			options.FieldSelector = index.FieldSelector
+		}
+		if index.LabelSelector != "" {
+			options.LabelSelector = index.LabelSelector
+		}
+	}
+
+	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(
+		client, resyncPeriod, index.Namespace, tweakListOptions)
+	factory.ForResource(index.GVR)
+
+	c.add(index, factory)
+	return c.data[index]
+}
+
+func (c *FactoryStore) Start(client dynamic.Interface, index FactoryIndex, handler cache.ResourceEventHandler) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.data[index] = f
+	factory := c.get(client, index)
+
+	informer := factory.shared.ForResource(index.GVR).Informer()
+	// TODO(nabokihms): think about what will happen if we stop and then start the monitor
+	informer.AddEventHandler(handler)
+
+	if !informer.HasSynced() {
+		go informer.Run(factory.stopCh)
+
+		if err := wait.PollImmediateUntil(DefaultSyncTime, func() (bool, error) {
+			return informer.HasSynced(), nil
+		}, factory.stopCh); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *FactoryStore) Stop(index FactoryIndex) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	f, ok := c.data[index]
+	if !ok {
+		// already deleted
+		return
+	}
+
+	f.score--
+	if f.score == 0 {
+		close(f.stopCh)
+	}
+
+	delete(c.data, index)
 }

--- a/pkg/kube_events_manager/factory.go
+++ b/pkg/kube_events_manager/factory.go
@@ -1,0 +1,47 @@
+package kube_events_manager
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+)
+
+var DefaultFactoryCache *FactoryCache
+
+func init() {
+	DefaultFactoryCache = NewFactoryCache()
+}
+
+type FactoryIndex struct {
+	GVR           schema.GroupVersionResource
+	Namespace     string
+	FieldSelector string
+	LabelSelector string
+}
+
+type FactoryCache struct {
+	mu   sync.RWMutex
+	data map[FactoryIndex]dynamicinformer.DynamicSharedInformerFactory
+}
+
+func NewFactoryCache() *FactoryCache {
+	return &FactoryCache{
+		data: make(map[FactoryIndex]dynamicinformer.DynamicSharedInformerFactory),
+	}
+}
+
+func (c *FactoryCache) Get(index FactoryIndex) dynamicinformer.DynamicSharedInformerFactory {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	f, _ := c.data[index]
+	return f
+}
+
+func (c *FactoryCache) Add(index FactoryIndex, f dynamicinformer.DynamicSharedInformerFactory) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.data[index] = f
+}

--- a/pkg/kube_events_manager/kube_events_manager.go
+++ b/pkg/kube_events_manager/kube_events_manager.go
@@ -3,7 +3,6 @@ package kube_events_manager
 import (
 	"context"
 	"runtime/trace"
-	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -16,7 +15,6 @@ type KubeEventsManager interface {
 	WithContext(ctx context.Context)
 	WithMetricStorage(mstor *metric_storage.MetricStorage)
 	WithKubeClient(client klient.Client)
-	WithSyncPeriod(time.Duration)
 	AddMonitor(monitorConfig *MonitorConfig) error
 	HasMonitor(monitorID string) bool
 	GetMonitor(monitorID string) Monitor
@@ -32,8 +30,7 @@ type kubeEventsManager struct {
 	// Array of monitors
 	Monitors map[string]Monitor
 	// channel to emit KubeEvent objects
-	KubeEventCh      chan KubeEvent
-	informerSyncTime time.Duration
+	KubeEventCh chan KubeEvent
 
 	KubeClient klient.Client
 
@@ -48,9 +45,8 @@ var _ KubeEventsManager = &kubeEventsManager{}
 // NewKubeEventsManager returns an implementation of KubeEventsManager.
 var NewKubeEventsManager = func() *kubeEventsManager {
 	em := &kubeEventsManager{
-		Monitors:         make(map[string]Monitor),
-		KubeEventCh:      make(chan KubeEvent, 1),
-		informerSyncTime: 100 * time.Millisecond,
+		Monitors:    make(map[string]Monitor),
+		KubeEventCh: make(chan KubeEvent, 1),
 	}
 	return em
 }
@@ -67,10 +63,6 @@ func (mgr *kubeEventsManager) WithKubeClient(client klient.Client) {
 	mgr.KubeClient = client
 }
 
-func (mgr *kubeEventsManager) WithSyncPeriod(period time.Duration) {
-	mgr.informerSyncTime = period
-}
-
 // AddMonitor creates a monitor with informers and return a KubeEvent with existing objects.
 // TODO cleanup informers in case of error
 // TODO use Context to stop informers
@@ -81,7 +73,6 @@ func (mgr *kubeEventsManager) AddMonitor(monitorConfig *MonitorConfig) error {
 	monitor.WithKubeClient(mgr.KubeClient)
 	monitor.WithMetricStorage(mgr.metricStorage)
 	monitor.WithConfig(monitorConfig)
-	monitor.WithSyncPeriod(mgr.informerSyncTime)
 	monitor.WithKubeEventCb(func(ev KubeEvent) {
 		defer trace.StartRegion(context.Background(), "EmitKubeEvent").End()
 		mgr.KubeEventCh <- ev

--- a/pkg/kube_events_manager/resource_informer.go
+++ b/pkg/kube_events_manager/resource_informer.go
@@ -11,8 +11,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/tools/cache"
 
 	klient "github.com/flant/kube-client/client"
@@ -29,7 +27,6 @@ type ResourceInformer interface {
 	WithNamespace(string)
 	WithName(string)
 	WithKubeEventCb(eventCb func(KubeEvent))
-	WithSyncPeriod(time.Duration)
 	CreateSharedInformer() error
 	CachedObjects() []ObjectAndFilterResult
 	CachedObjectsBytes() int64
@@ -50,10 +47,9 @@ type resourceInformer struct {
 	Name string
 
 	// Kubernetes informer and its settings.
-	SharedInformer       cache.SharedInformer
+	FactoryIndex         FactoryIndex
 	GroupVersionResource schema.GroupVersionResource
 	ListOptions          metav1.ListOptions
-	informerSyncTime     time.Duration
 
 	// A cache of objects and filterResults. It is a part of the Monitor's snapshot.
 	cachedObjects map[string]*ObjectAndFilterResult
@@ -94,7 +90,6 @@ var NewResourceInformer = func(monitor *MonitorConfig) ResourceInformer {
 		eventBufLock:           sync.Mutex{},
 		cachedObjectsInfo:      &CachedObjectsInfo{},
 		cachedObjectsIncrement: &CachedObjectsInfo{},
-		informerSyncTime:       100 * time.Millisecond,
 	}
 	return informer
 }
@@ -119,10 +114,6 @@ func (ei *resourceInformer) WithName(name string) {
 	ei.Name = name
 }
 
-func (ei *resourceInformer) WithSyncPeriod(period time.Duration) {
-	ei.informerSyncTime = period
-}
-
 func (ei *resourceInformer) WithKubeEventCb(eventCb func(KubeEvent)) {
 	ei.eventCb = eventCb
 }
@@ -143,9 +134,6 @@ func (ei *resourceInformer) CreateSharedInformer() (err error) {
 	}
 	log.Debugf("%s: GVR for kind '%s' is '%s'", ei.Monitor.Metadata.DebugName, ei.Monitor.Kind, ei.GroupVersionResource.String())
 
-	// define resyncPeriod for informer
-	resyncPeriod := RandomizedResyncPeriod()
-
 	// define tweakListOptions for informer
 	fmtLabelSelector, err := FormatLabelSelector(ei.Monitor.LabelSelector)
 	if err != nil {
@@ -158,36 +146,17 @@ func (ei *resourceInformer) CreateSharedInformer() (err error) {
 		return fmt.Errorf("format field selector '%+v': %s", fieldSelector, err)
 	}
 
-	tweakListOptions := func(options *metav1.ListOptions) {
-		if fmtFieldSelector != "" {
-			options.FieldSelector = fmtFieldSelector
-		}
-		if fmtLabelSelector != "" {
-			options.LabelSelector = fmtLabelSelector
-		}
-	}
-	ei.ListOptions = metav1.ListOptions{}
-	tweakListOptions(&ei.ListOptions)
-
-	// create informer with add, update, delete callbacks
-	index := FactoryIndex{
-		GVR:           ei.GroupVersionResource,
-		Namespace:     ei.Namespace,
+	ei.ListOptions = metav1.ListOptions{
 		FieldSelector: fmtFieldSelector,
 		LabelSelector: fmtLabelSelector,
 	}
 
-	factory := DefaultFactoryCache.Get(index)
-	if factory == nil {
-		factory = dynamicinformer.NewFilteredDynamicSharedInformerFactory(
-			ei.KubeClient.Dynamic(), resyncPeriod, ei.Namespace, tweakListOptions)
-		DefaultFactoryCache.Add(index, factory)
+	ei.FactoryIndex = FactoryIndex{
+		GVR:           ei.GroupVersionResource,
+		Namespace:     ei.Namespace,
+		FieldSelector: ei.ListOptions.FieldSelector,
+		LabelSelector: ei.ListOptions.LabelSelector,
 	}
-
-	informer := factory.ForResource(ei.GroupVersionResource)
-	informer.Informer().AddEventHandler(ei)
-
-	ei.SharedInformer = informer.Informer()
 
 	err = ei.LoadExistedObjects()
 	if err != nil {
@@ -240,6 +209,7 @@ func (ei *resourceInformer) CachedObjectsBytes() int64 {
 // fills Checksum map with checksums of existing objects.
 func (ei *resourceInformer) LoadExistedObjects() error {
 	defer trace.StartRegion(context.Background(), "LoadExistedObjects").End()
+
 	objList, err := ei.KubeClient.Dynamic().
 		Resource(ei.GroupVersionResource).
 		Namespace(ei.Namespace).
@@ -491,31 +461,26 @@ func (ei *resourceInformer) ShouldFireEvent(checkEvent WatchEventType) bool {
 
 func (ei *resourceInformer) Start() {
 	log.Debugf("%s: RUN resource informer", ei.Monitor.Metadata.DebugName)
-	stopCh := make(chan struct{}, 1)
+
 	go func() {
 		<-ei.ctx.Done()
 		ei.stopped = true
-		close(stopCh)
+		DefaultFactoryStore.Stop(ei.FactoryIndex)
 	}()
 
-	if !ei.SharedInformer.HasSynced() {
-		go ei.SharedInformer.Run(stopCh)
-
-		if err := wait.PollImmediateUntil(ei.informerSyncTime, func() (bool, error) {
-			return ei.SharedInformer.HasSynced(), nil
-		}, stopCh); err != nil {
-			ei.Monitor.LogEntry.Errorf("%s: cache is not synced for informer", ei.Monitor.Metadata.DebugName)
-		}
-
-		log.Debugf("%s: informer is ready", ei.Monitor.Metadata.DebugName)
+	// TODO: separate handler and informer
+	err := DefaultFactoryStore.Start(ei.KubeClient.Dynamic(), ei.FactoryIndex, ei)
+	if err != nil {
+		ei.Monitor.LogEntry.Errorf("%s: cache is not synced for informer", ei.Monitor.Metadata.DebugName)
+		return
 	}
+
+	log.Debugf("%s: informer is ready", ei.Monitor.Metadata.DebugName)
 }
 
 func (ei *resourceInformer) Stop() {
 	log.Debugf("%s: STOP resource informer", ei.Monitor.Metadata.DebugName)
-	if ei.cancel != nil {
-		ei.cancel()
-	}
+	DefaultFactoryStore.Stop(ei.FactoryIndex)
 	ei.stopped = true
 }
 

--- a/pkg/kube_events_manager/resource_informer.go
+++ b/pkg/kube_events_manager/resource_informer.go
@@ -462,12 +462,6 @@ func (ei *resourceInformer) ShouldFireEvent(checkEvent WatchEventType) bool {
 func (ei *resourceInformer) Start() {
 	log.Debugf("%s: RUN resource informer", ei.Monitor.Metadata.DebugName)
 
-	go func() {
-		<-ei.ctx.Done()
-		ei.stopped = true
-		DefaultFactoryStore.Stop(ei.FactoryIndex)
-	}()
-
 	// TODO: separate handler and informer
 	err := DefaultFactoryStore.Start(ei.KubeClient.Dynamic(), ei.FactoryIndex, ei)
 	if err != nil {

--- a/test/hook/context/generator.go
+++ b/test/hook/context/generator.go
@@ -17,6 +17,10 @@ import (
 	schedulemanager "github.com/flant/shell-operator/pkg/schedule_manager"
 )
 
+func init() {
+	kubeeventsmanager.DefaultSyncTime = time.Microsecond
+}
+
 type GeneratedBindingContexts struct {
 	Rendered        string
 	BindingContexts []BindingContext
@@ -58,7 +62,6 @@ func NewBindingContextController(config string, version ...fake.ClusterVersion) 
 	b.KubeEventsManager = kubeeventsmanager.NewKubeEventsManager()
 	b.KubeEventsManager.WithContext(ctx)
 	b.KubeEventsManager.WithKubeClient(b.fakeCluster.Client)
-	b.KubeEventsManager.WithSyncPeriod(time.Microsecond)
 
 	b.ScheduleManager = schedulemanager.NewScheduleManager()
 	b.ScheduleManager.WithContext(ctx)
@@ -132,9 +135,6 @@ func (b *BindingContextController) Run(initialState string) (GeneratedBindingCon
 }
 
 func (b *BindingContextController) ChangeState(newState string) (GeneratedBindingContexts, error) {
-	// fmt.Println("Change state start")
-	// defer func() { fmt.Println("Change state end") }()
-
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -195,5 +195,5 @@ func (b *BindingContextController) Stop() {
 	if b.HookCtrl != nil {
 		b.HookCtrl.StopMonitors()
 	}
-	kubeeventsmanager.DefaultFactoryCache = kubeeventsmanager.NewFactoryCache()
+	kubeeventsmanager.DefaultFactoryStore = kubeeventsmanager.NewFactoryStore()
 }

--- a/test/hook/context/generator.go
+++ b/test/hook/context/generator.go
@@ -195,4 +195,5 @@ func (b *BindingContextController) Stop() {
 	if b.HookCtrl != nil {
 		b.HookCtrl.StopMonitors()
 	}
+	kubeeventsmanager.DefaultFactoryCache = kubeeventsmanager.NewFactoryCache()
 }

--- a/test/hook/context/generator_test.go
+++ b/test/hook/context/generator_test.go
@@ -32,6 +32,7 @@ schedule:
   includeSnapshotsFrom:
   - selected_pods
 `)
+	defer c.Stop()
 
 	// Synchronization contexts
 	contexts, err := c.Run(`
@@ -145,6 +146,7 @@ kubernetes:
   name: selected_crds
 `)
 	c.RegisterCRD("my.crd.io", "v1alpha1", "MyResource", true)
+	defer c.Stop()
 
 	gvr, err := c.fakeCluster.FindGVR("my.crd.io/v1alpha1", "MyResource")
 	g.Expect(err).ShouldNot(HaveOccurred())
@@ -197,6 +199,8 @@ kind: Deployment
 metadata:
   name: my-res-obj-2
 `)
+	defer c.Stop()
+
 	g.Expect(err).ShouldNot(HaveOccurred())
 
 	bindingContexts := parseContexts(contexts.Rendered)
@@ -239,6 +243,8 @@ kubernetes:
   name: pods-grouped
   group: group1
 `)
+	defer c.Stop()
+
 	contexts, err := c.Run(`
 ---
 apiVersion: apps/v1
@@ -282,6 +288,8 @@ kubernetes:
   kind: Secret
   name: secret
 `)
+	defer c.Stop()
+
 	contexts, err := c.Run(`
 ---
 apiVersion: apps/v1
@@ -322,6 +330,8 @@ kubernetes:
   name: selected_pods_nosync
   executeHookOnSynchronization: false
 `)
+	defer c.Stop()
+
 	// Synchronization contexts
 	contexts, err := c.Run(`
 ---
@@ -364,6 +374,8 @@ schedule:
   includeSnapshotsFrom:
   - selected_pods
 `)
+	defer c.Stop()
+
 	// Synchronization contexts
 	contexts, err := c.Run(`
 ---

--- a/test/hook/context/state.go
+++ b/test/hook/context/state.go
@@ -95,7 +95,7 @@ func (c *StateController) ChangeState(newRawState string) error {
 	}
 
 	go func() {
-		time.Sleep(20 * time.Millisecond)
+		time.Sleep(100 * time.Millisecond)
 		c.stopCh <- types.KubeEvent{MonitorId: "STOP_EVENTS"}
 	}()
 


### PR DESCRIPTION
#### Overview

Reuse watch and cache for informers

#### What this PR does / why we need it

The most resources shell-operator consume to encode and decode watch events.

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```