### PR TITLE
feat: remove kube_snapshot_bytes metric and size calculations

### DIFF
--- a/METRICS.md
+++ b/METRICS.md
@@ -24,9 +24,7 @@ Shell-operator exports Prometheus metrics to the `/metrics` path. The default po
 
 * `shell_operator_kube_snapshot_objects{hook="", binding="", queue=""}` — a gauge with count of cached objects (the snapshot) for particular binding.
 
-* `shell_operator_kube_snapshot_bytes{hook="", binding="", queue=""}` — a gauge with size in bytes of cached objects for particular binding. Each cached object contains a Kubernetes object and/or result of jqFilter depending on the binding configuration. The size is a sum of the length of Kubernetes object in JSON format and the length of jqFilter‘s result in JSON format.
-
-* `shell_operator_kubernetes_client_request_result_total` — a counter of requests made by kubernetes/client-go library. 
+* `shell_operator_kubernetes_client_request_result_total` — a counter of requests made by kubernetes/client-go library.
 
 * `shell_operator_kubernetes_client_request_latency_seconds` — a histogram with latency of requests made by kubernetes/client-go library. 
 

--- a/pkg/kube_events_manager/filter.go
+++ b/pkg/kube_events_manager/filter.go
@@ -27,12 +27,6 @@ func ApplyFilter(jqFilter string, filterFn func(obj *unstructured.Unstructured) 
 	res.Metadata.JqFilter = jqFilter
 	res.Metadata.ResourceId = ResourceId(obj)
 
-	data, err := json.Marshal(obj)
-	if err != nil {
-		return nil, err
-	}
-	res.ObjectSize = len(data)
-
 	// If filterFn is passed, run it and return result.
 	if filterFn != nil {
 		filteredObj, err := filterFn(obj)
@@ -46,10 +40,15 @@ func ApplyFilter(jqFilter string, filterFn func(obj *unstructured.Unstructured) 
 		}
 
 		res.FilterResult = filteredObj
-		res.FilterResultSize = len(filteredBytes)
 		res.Metadata.Checksum = utils_checksum.CalculateChecksum(string(filteredBytes))
 
 		return res, nil
+	}
+
+	// Render obj to JSON text to apply jq filter.
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return nil, err
 	}
 
 	if jqFilter == "" {
@@ -63,7 +62,6 @@ func ApplyFilter(jqFilter string, filterFn func(obj *unstructured.Unstructured) 
 		}
 
 		res.FilterResult = filtered
-		res.FilterResultSize = len(filtered)
 		res.Metadata.Checksum = utils_checksum.CalculateChecksum(filtered)
 	}
 

--- a/pkg/kube_events_manager/types/types.go
+++ b/pkg/kube_events_manager/types/types.go
@@ -42,9 +42,6 @@ type ObjectAndFilterResult struct {
 	}
 	Object       *unstructured.Unstructured // here is a pointer because of MarshalJSON receiver
 	FilterResult interface{}
-	// since len() return int, there is no reason to use larger int
-	FilterResultSize int
-	ObjectSize       int
 }
 
 // Map constructs a map suitable for use in binding context.
@@ -97,20 +94,10 @@ func (o ObjectAndFilterResult) MarshalJSON() ([]byte, error) {
 
 func (o *ObjectAndFilterResult) RemoveFullObject() {
 	o.Object = nil
-	o.ObjectSize = 0
 	o.Metadata.RemoveObject = true
 }
 
 type ObjectAndFilterResults map[string]*ObjectAndFilterResult
-
-func (a ObjectAndFilterResults) Bytes() (size int64) {
-	for _, o := range a {
-		size += int64(o.FilterResultSize)
-		size += int64(o.ObjectSize)
-	}
-
-	return
-}
 
 // ByNamespaceAndName implements sort.Interface for []ObjectAndFilterResult
 // based on Namespace and Name of Object field.

--- a/pkg/shell-operator/metrics_operator.go
+++ b/pkg/shell-operator/metrics_operator.go
@@ -54,8 +54,6 @@ func RegisterTaskQueueMetrics(metricStorage *metric_storage.MetricStorage) {
 func RegisterKubeEventsManagerMetrics(metricStorage *metric_storage.MetricStorage, labels map[string]string) {
 	// Count of objects in snapshot for one kubernets bindings.
 	metricStorage.RegisterGauge("{PREFIX}kube_snapshot_objects", labels)
-	// Size of snapshot in JSON format.
-	metricStorage.RegisterGauge("{PREFIX}kube_snapshot_bytes", labels)
 	// Duration of jqFilter applying.
 	metricStorage.RegisterHistogram(
 		"{PREFIX}kube_jq_filter_duration_seconds",


### PR DESCRIPTION

#### Overview

Remove kube_snapshot_bytes metric and snapshot size calculations.

#### What this PR does / why we need it

This metric is not reliable:
- Informers cache objects internally.
- Informers factory reduce memory footprint.
- `keepFullObjectsInMemory: false` removes object size from metric.
- Metric value not correlate with total memory consumtion, it may be 5MiB and shell-operator consume 1.5GiB.

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
- Remove kube_snapshot_bytes metric.
```