### PR TITLE
fix: initialize informers factory at generator start

### DIFF
--- a/test/hook/context/generator.go
+++ b/test/hook/context/generator.go
@@ -62,6 +62,8 @@ func NewBindingContextController(config string, version ...fake.ClusterVersion) 
 	b.KubeEventsManager = kubeeventsmanager.NewKubeEventsManager()
 	b.KubeEventsManager.WithContext(ctx)
 	b.KubeEventsManager.WithKubeClient(b.fakeCluster.Client)
+	// Re-create factory to drop informers created using different b.fakeCluster.Client.
+	kubeeventsmanager.DefaultFactoryStore = kubeeventsmanager.NewFactoryStore()
 
 	b.ScheduleManager = schedulemanager.NewScheduleManager()
 	b.ScheduleManager.WithContext(ctx)
@@ -195,5 +197,4 @@ func (b *BindingContextController) Stop() {
 	if b.HookCtrl != nil {
 		b.HookCtrl.StopMonitors()
 	}
-	kubeeventsmanager.DefaultFactoryStore = kubeeventsmanager.NewFactoryStore()
 }


### PR DESCRIPTION
#### Overview

Create new informers factory on creating BindingContextController in testing generator.

#### What this PR does / why we need it

Informer is cached with fake client and tests become broken. See https://github.com/deckhouse/deckhouse-test-1/actions/runs/3206032635/jobs/5239370058

Alternative solution is to add AfterEach to all tests https://github.com/deckhouse/deckhouse/pull/1937/files. Creating new factory at start seems more logical.

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```