### PR TITLE
fix: run metrics storage after bootstraping queues

### DIFF
--- a/pkg/shell-operator/operator.go
+++ b/pkg/shell-operator/operator.go
@@ -364,14 +364,14 @@ func (op *ShellOperator) ConversionEventHandler(event conversion.Event) (*conver
 func (op *ShellOperator) Start() {
 	log.Info("start shell-operator")
 
-	// Start emit "live" metrics
-	op.RunMetrics()
-
 	// Create 'main' queue and add onStartup tasks and enable bindings tasks.
 	op.BootstrapMainQueue(op.TaskQueues)
 	// Start main task queue handler
 	op.TaskQueues.StartMain()
 	op.InitAndStartHookQueues()
+
+	// Start emit "live" metrics
+	op.RunMetrics()
 
 	// Managers are generating events. This go-routine handles all events and converts them into queued tasks.
 	// Start it before start all informers to catch all kubernetes events (#42)


### PR DESCRIPTION
#### Overview

RunMetrics starts go routines that access the TaskQueueSet info thus data race appears at start.

```
==================
WARNING: DATA RACE
Read at 0x00c00026fbc0 by goroutine 50:
  github.com/flant/shell-operator/pkg/task/queue.(*TaskQueueSet).Iterate()
  github.com/flant/shell-operator/pkg/shell-operator.(*ShellOperator).RunMetrics.func2()

Previous write at 0x00c00026fbc0 by main goroutine:
  runtime.mapassign_faststr()
      /usr/local/Cellar/go/1.17.2/libexec/src/runtime/map_faststr.go:202 +0x0
  github.com/flant/shell-operator/pkg/task/queue.(*TaskQueueSet).NewNamedQueue()
...

Goroutine 50 (running) created at:
  github.com/flant/shell-operator/pkg/shell-operator.(*ShellOperator).RunMetrics()
...
```

