### PR TITLE
feat: add watch error handler for Kubernetes client

### DIFF
--- a/pkg/kube_events_manager/error_handler.go
+++ b/pkg/kube_events_manager/error_handler.go
@@ -1,0 +1,63 @@
+package kube_events_manager
+
+import (
+	log "github.com/sirupsen/logrus"
+	"io"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/flant/shell-operator/pkg/metric_storage"
+	utils "github.com/flant/shell-operator/pkg/utils/labels"
+)
+
+type WatchErrorHandler struct {
+	description   string
+	kind          string
+	logEntry      *log.Entry
+	metricStorage *metric_storage.MetricStorage
+}
+
+func NewWatchErrorHandler(description string, kind string, logLabels map[string]string, metricStorage *metric_storage.MetricStorage) *WatchErrorHandler {
+	return &WatchErrorHandler{
+		description:   description,
+		kind:          kind,
+		logEntry:      log.WithFields(utils.LabelsToLogFields(logLabels)),
+		metricStorage: metricStorage,
+	}
+}
+
+// Handler is the implementation of WatchErrorHandler that is aware of monitors and metricStorage
+func (weh *WatchErrorHandler) Handler(_ *cache.Reflector, err error) {
+	errorType := "nil"
+
+	switch {
+	case IsExpiredError(err):
+		// Don't set LastSyncResourceVersionUnavailable - LIST call with ResourceVersion=RV already
+		// has a semantic that it returns data at least as fresh as provided RV.
+		// So first try to LIST with setting RV to resource version of last observed object.
+		weh.logEntry.Errorf("%s: Watch of %v closed with: %v", weh.description, weh.kind, err)
+		errorType = "expired"
+	case err == io.EOF:
+		// watch closed normally
+		errorType = "eof"
+	case err == io.ErrUnexpectedEOF:
+		weh.logEntry.Errorf("%s: Watch for %v closed with unexpected EOF: %v", weh.description, weh.kind, err)
+		errorType = "unexpected-eof"
+	case err != nil:
+		weh.logEntry.Errorf("%s: Failed to watch %v: %v", weh.description, weh.kind, err)
+		errorType = "fail"
+	}
+
+	if weh.metricStorage != nil {
+		weh.metricStorage.CounterAdd("{PREFIX}kubernetes_client_watch_errors_total", 1.0, map[string]string{"error_type": errorType})
+	}
+}
+
+// IsExpiredError is a private method from k8s.io/client-go/tools/cache.
+func IsExpiredError(err error) bool {
+	// In Kubernetes 1.17 and earlier, the api server returns both apierrors.StatusReasonExpired and
+	// apierrors.StatusReasonGone for HTTP 410 (Gone) status code responses. In 1.18 the kube server is more consistent
+	// and always returns apierrors.StatusReasonExpired. For backward compatibility we can only remove the apierrors.IsGone
+	// check when we fully drop support for Kubernetes 1.17 servers from reflectors.
+	return apierrors.IsResourceExpired(err) || apierrors.IsGone(err)
+}

--- a/pkg/kube_events_manager/factory.go
+++ b/pkg/kube_events_manager/factory.go
@@ -80,13 +80,15 @@ func (c *FactoryStore) get(client dynamic.Interface, index FactoryIndex) Factory
 	return c.data[index]
 }
 
-func (c *FactoryStore) Start(client dynamic.Interface, index FactoryIndex, handler cache.ResourceEventHandler) error {
+func (c *FactoryStore) Start(client dynamic.Interface, index FactoryIndex, handler cache.ResourceEventHandler, errorHandler *WatchErrorHandler) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	factory := c.get(client, index)
 
 	informer := factory.shared.ForResource(index.GVR).Informer()
+	// Add error handler, ignore "already started" error.
+	_ = informer.SetWatchErrorHandler(errorHandler.Handler)
 	// TODO(nabokihms): think about what will happen if we stop and then start the monitor
 	informer.AddEventHandler(handler)
 

--- a/pkg/kube_events_manager/resource_informer.go
+++ b/pkg/kube_events_manager/resource_informer.go
@@ -280,7 +280,7 @@ func (ei *resourceInformer) OnDelete(obj interface{}) {
 // HandleKubeEvent register object in cache. Pass object to callback if object's checksum is changed.
 // TODO refactor: pass KubeEvent as argument
 // TODO add delay to merge Added and Modified events (node added and then labels applied — one hook run on Added+Modified is enough)
-//func (ei *resourceInformer) HandleKubeEvent(obj *unstructured.Unstructured, objectId string, filterResult string, newChecksum string, eventType WatchEventType) {
+// func (ei *resourceInformer) HandleKubeEvent(obj *unstructured.Unstructured, objectId string, filterResult string, newChecksum string, eventType WatchEventType) {
 func (ei *resourceInformer) HandleWatchEvent(object interface{}, eventType WatchEventType) {
 	// check if stop
 	if ei.stopped {
@@ -460,7 +460,8 @@ func (ei *resourceInformer) Start() {
 	}()
 
 	// TODO: separate handler and informer
-	err := DefaultFactoryStore.Start(ei.KubeClient.Dynamic(), ei.FactoryIndex, ei)
+	errorHandler := NewWatchErrorHandler(ei.Monitor.Metadata.DebugName, ei.Monitor.Kind, ei.Monitor.Metadata.LogLabels, ei.metricStorage)
+	err := DefaultFactoryStore.Start(ei.KubeClient.Dynamic(), ei.FactoryIndex, ei, errorHandler)
 	if err != nil {
 		ei.Monitor.LogEntry.Errorf("%s: cache is not synced for informer", ei.Monitor.Metadata.DebugName)
 		return

--- a/pkg/shell-operator/metrics_operator.go
+++ b/pkg/shell-operator/metrics_operator.go
@@ -78,6 +78,9 @@ func RegisterKubeEventsManagerMetrics(metricStorage *metric_storage.MetricStorag
 			1, 2, 5, 10, // 1,2,5,10 seconds
 		},
 	)
+
+	// Count of watch errors.
+	metricStorage.RegisterCounter("{PREFIX}kubernetes_client_watch_errors_total", map[string]string{"error_type": ""})
 }
 
 // Shell-operator specific metrics for HookManager


### PR DESCRIPTION
#### Overview

Add WatchErrorHandler implementation to log informer errors and increase new metric counter.


#### What this PR does / why we need it

shell-operator will log messages about problems with connection to the apiserver:

```
{"hook":"pods-v1.sh","level":"error","msg":"kubernetes[0]{crontabs}: Failed to watch ct: failed to list *unstructured.Unstructured: Get \"https://10.96.0.1:443/apis/stable.example.com/v1/crontabs?resourceVersion=369642\": dial tcp 10.96.0.1:443: connect: connection refused","time":"2022-12-13T11:59:21Z"}
```

```
# HELP shell_operator_kubernetes_client_watch_errors_total shell_operator_kubernetes_client_watch_errors_total
# TYPE shell_operator_kubernetes_client_watch_errors_total counter
shell_operator_kubernetes_client_watch_errors_total{error_type="fail"} 15
```
<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```