### PR TITLE
fix: execute jq binary without absolute path

### DIFF
--- a/cmd/shell-operator/main.go
+++ b/cmd/shell-operator/main.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/flant/kube-client/klogtologrus"
+	"github.com/flant/shell-operator/pkg/jq"
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/flant/shell-operator/pkg/app"
@@ -30,6 +31,7 @@ func main() {
 	// print version
 	kpApp.Command("version", "Show version.").Action(func(c *kingpin.ParseContext) error {
 		fmt.Printf("%s %s\n", app.AppName, app.Version)
+		fmt.Println(jq.JqFilterInfo())
 		return nil
 	})
 

--- a/pkg/jq/apply_jq_exec.go
+++ b/pkg/jq/apply_jq_exec.go
@@ -1,3 +1,4 @@
+//go:build !cgo || (cgo && !use_libjq)
 // +build !cgo cgo,!use_libjq
 
 package jq
@@ -12,5 +13,5 @@ func ApplyJqFilter(jqFilter string, jsonData []byte, libPath string) (string, er
 }
 
 func JqFilterInfo() string {
-	return "Use jq binary for jqFilter"
+	return "jqFilter implementation: use jq binary from $PATH"
 }

--- a/pkg/jq/apply_libjq-go.go
+++ b/pkg/jq/apply_libjq-go.go
@@ -1,3 +1,4 @@
+//go:build cgo && use_libjq
 // +build cgo,use_libjq
 
 package jq
@@ -29,7 +30,7 @@ func ApplyJqFilter(jqFilter string, jsonData []byte, libPath string) (string, er
 
 func JqFilterInfo() string {
 	if os.Getenv("JQ_EXEC") == "yes" {
-		return "JQ_EXEC is set, use jq binary for jqFilter"
+		return "jqFilter implementation: use jq binary from $PATH (JQ_EXEC=yes is set)"
 	}
-	return "Use libjq-go for jqFilter"
+	return "jqFilter implementation: use embedded libjq-go"
 }

--- a/pkg/jq/jq_exec.go
+++ b/pkg/jq/jq_exec.go
@@ -13,9 +13,9 @@ import (
 func jqExec(jqFilter string, jsonData []byte, libPath string) (result string, err error) {
 	var cmd *exec.Cmd
 	if libPath == "" {
-		cmd = exec.Command("/usr/bin/jq", jqFilter)
+		cmd = exec.Command("jq", jqFilter)
 	} else {
-		cmd = exec.Command("/usr/bin/jq", "-L", libPath, jqFilter)
+		cmd = exec.Command("jq", "-L", libPath, jqFilter)
 	}
 
 	var stdinBuf bytes.Buffer


### PR DESCRIPTION

<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

- execute jq binary without absolute path
- 'version' command now prints jq implementation info


<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

Absolute path makes local testing problematic.

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```