### PR TITLE
feat(ci): store images in ghcr.io/flant/shell-operator

### DIFF
--- a/.github/workflows/publish-dev.yaml
+++ b/.github/workflows/publish-dev.yaml
@@ -1,5 +1,7 @@
-# Publish flant/shell-operator-dev image to hub.docker.com.
+# Publish flant/shell-operator-dev image to hub.docker.com and ghcr.io.
 # Start when PR is labeled with 'publish/image/dev' or 'publish/image/dev/amd64'.
+# Label 'publish/image/dev/amd64' publishes image only for amd64 arhitecture.
+# Label 'publish/image/dev' publishes a multi-arch image, it is a long-lasting operation (~1h).
 name: Publish dev image
 on:
   pull_request:
@@ -8,7 +10,8 @@ env:
   QEMU_PLATFORMS: arm64,arm
   BUILDX_PLATFORMS: "linux/amd64,linux/arm64,linux/arm/v7"
   BUILDX_PLATFORMS_AMD64: "linux/amd64"
-  IMAGE_REPO: flant/shell-operator-dev
+  DOCKER_HUB_REPO: flant/shell-operator-dev
+  GHCR_IO_REPO: ghcr.io/flant/shell-operator-dev
 
 jobs:
   check:
@@ -75,14 +78,17 @@ jobs:
           : Image name and version for dev image
           # Example: dev-feat_branch-371e2d3b-2020.02.06_18:37:42
           APP_VERSION=dev-${GITHUB_REF#refs/heads/}-${GITHUB_SHA::8}-$(date +'%Y.%m.%d_%H:%M:%S')
-          FINAL_IMAGE_NAME="${IMAGE_REPO}:pr${{ github.event.pull_request.number }}"
+          DOCKER_HUB_IMAGE_NAME="${DOCKER_HUB_REPO}:pr${{ github.event.pull_request.number }}"
+          GHCR_IO_IMAGE_NAME="${GHCR_IO_REPO}:pr${{ github.event.pull_request.number }}"
 
           echo "APP_VERSION=${APP_VERSION}" >> ${GITHUB_ENV}
-          echo "FINAL_IMAGE_NAME=${FINAL_IMAGE_NAME}" >> ${GITHUB_ENV}
+          echo "DOCKER_HUB_IMAGE_NAME=${DOCKER_HUB_IMAGE_NAME}" >> ${GITHUB_ENV}
+          echo "GHCR_IO_IMAGE_NAME=${GHCR_IO_IMAGE_NAME}" >> ${GITHUB_ENV}
 
           echo "========================================="
-          echo "APP_VERSION        = $APP_VERSION"
-          echo "FINAL_IMAGE_NAME   = $FINAL_IMAGE_NAME"
+          echo "APP_VERSION             = $APP_VERSION"
+          echo "DOCKER_HUB_IMAGE_NAME   = $DOCKER_HUB_IMAGE_NAME"
+          echo "GHCR_IO_IMAGE_NAME      = $GHCR_IO_IMAGE_NAME"
           echo "========================================="
 
           if [[ ${BUILD_MULTI_ARCH} == "false" ]] ; then
@@ -104,30 +110,32 @@ jobs:
         with:
           version: latest
 
-      - name: Login to DockerHub
+      - name: Login to Github Container Registry
         uses: docker/login-action@v2.1.0
         with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PASS }}
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_USER }}
+          password: ${{ secrets.GHCR_IO_PASS }}
 
       - name: Build and push using buildx
         run: |
-          echo "Build $FINAL_IMAGE_NAME with version '$APP_VERSION'"
-          docker buildx build --push \
+          echo "Build ${GHCR_IO_IMAGE_NAME} with version '${APP_VERSION}'"
+          docker buildx build \
               --platform $BUILDX_PLATFORMS \
               --build-arg appVersion=$APP_VERSION \
-              --tag $FINAL_IMAGE_NAME .
+              --tag $GHCR_IO_IMAGE_NAME \
+              --push .
 
       - name: Inspect binaries
         if: needs.check.outputs.build_multi_arch == 'true'
         run: |
           # Image for one arhitecture has digest in config field.
           # Image with multiple manifests has digest in each manifest.
-          manifests=$(docker buildx imagetools inspect "${FINAL_IMAGE_NAME}" --raw)
+          manifests=$(docker buildx imagetools inspect "${GHCR_IO_IMAGE_NAME}" --raw)
           if grep manifests <<<"${manifests}" 2>&1 >/dev/null ; then
             jq -r '.manifests[]? | .digest + " " + .platform.os + "/" + .platform.architecture' <<<"${manifests}" \
             | while read digest platform ; do
-              image=$FINAL_IMAGE_NAME@${digest}
+            image=${GHCR_IO_IMAGE_NAME}@${digest}
               echo "====================================="
               echo "Inspect image for platform ${platform}"
               echo "  ${image}"
@@ -136,6 +144,22 @@ jobs:
                 'apk add file > /dev/null; file /bin/kubectl; file /bin/busybox; file /shell-operator'
             done
           else
-            echo Not a multiarhitecture image.
+            echo Not a multi-arhitecture image.
             #echo $(echo -n "${manifests}" | openssl dgst -sha256) ' linux/amd64'
           fi
+
+      - name: Copy image to Docker Hub
+        env:
+          DOCKER_USER: ${{ secrets.DOCKER_USER }}
+          DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
+        run: |
+          docker run \
+            -e "DOCKER_USER=${DOCKER_USER}" \
+            -e "DOCKER_PASS=${DOCKER_PASS}" \
+            -e "GHCR_IO_IMAGE_NAME=${GHCR_IO_IMAGE_NAME}" \
+            -e "DOCKER_HUB_IMAGE_NAME=${DOCKER_HUB_IMAGE_NAME}" \
+            quay.io/skopeo/stable:latest \
+              copy --all \
+              --dest-creds ${DOCKER_USER}:${DOCKER_PASS} \
+              docker://${GHCR_IO_IMAGE_NAME} \
+              docker://${DOCKER_HUB_IMAGE_NAME}

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -15,7 +15,8 @@ on:
 env:
   QEMU_PLATFORMS: arm64,arm
   BUILDX_PLATFORMS: "linux/amd64,linux/arm64,linux/arm/v7"
-  IMAGE_REPO: flant/shell-operator
+  DOCKER_HUB_REPO: flant/shell-operator
+  GHCR_IO_REPO: ghcr.io/flant/shell-operator
 
 jobs:
   check:
@@ -94,27 +95,33 @@ jobs:
           ADDITIONAL_TAG: ${{ needs.check.outputs.additional_tag }}
           IMAGE_TAG: ${{ needs.check.outputs.image_tag }}
         run: |
-          : Setup FINAL_IMAGE_NAME and APP_VERSION for image build
+          : Setup DOCKER_HUB_IMAGE_NAME, DOCKER_HUB_IMAGE_NAME and APP_VERSION for image build
           APP_VERSION=${IMAGE_TAG}
           if [[ $APP_VERSION == "latest" ]] ; then
             APP_VERSION=${GITHUB_REF#refs/heads/}-${GITHUB_SHA::8}-$(date +'%Y.%m.%d_%H:%M:%S')
           fi
 
-          FINAL_IMAGE_NAME="${IMAGE_REPO}:${IMAGE_TAG}"
+          DOCKER_HUB_IMAGE_NAME="${DOCKER_HUB_REPO}:${IMAGE_TAG}"
+          GHCR_IO_IMAGE_NAME="${GHCR_IO_REPO}:${IMAGE_TAG}"
 
           if [[ -n $ADDITIONAL_TAG ]] ; then
-            ADDITIONAL_IMAGE_NAME="${IMAGE_REPO}:${ADDITIONAL_TAG}"
+            ADDITIONAL_DOCKER_HUB_IMAGE_NAME="${DOCKER_HUB_REPO}:${ADDITIONAL_TAG}"
+            ADDITIONAL_GHCR_IO_IMAGE_NAME="${GHCR_IO_REPO}:${ADDITIONAL_TAG}"
           fi
 
           echo "APP_VERSION=${APP_VERSION}" >> ${GITHUB_ENV}
-          echo "FINAL_IMAGE_NAME=${FINAL_IMAGE_NAME}" >> ${GITHUB_ENV}
-          echo "ADDITIONAL_IMAGE_NAME=${ADDITIONAL_IMAGE_NAME}" >> ${GITHUB_ENV}
+          echo "DOCKER_HUB_IMAGE_NAME=${DOCKER_HUB_IMAGE_NAME}" >> ${GITHUB_ENV}
+          echo "ADDITIONAL_DOCKER_HUB_IMAGE_NAME=${ADDITIONAL_DOCKER_HUB_IMAGE_NAME}" >> ${GITHUB_ENV}
+          echo "GHCR_IO_IMAGE_NAME=${GHCR_IO_IMAGE_NAME}" >> ${GITHUB_ENV}
+          echo "ADDITIONAL_GHCR_IO_IMAGE_NAME=${ADDITIONAL_GHCR_IO_IMAGE_NAME}" >> ${GITHUB_ENV}
 
           echo "========================================="
           echo "APP_VERSION            = $APP_VERSION"
-          echo "FINAL_IMAGE_NAME       = $FINAL_IMAGE_NAME"
-          [ -n $ADDITIONAL_IMAGE_NAME ] && \
-          echo "ADDITIONAL_IMAGE_NAME  = $ADDITIONAL_IMAGE_NAME"
+          echo "DOCKER_HUB_IMAGE_NAME  = $DOCKER_HUB_IMAGE_NAME"
+          echo "GHCR_IO_IMAGE_NAME     = $GHCR_IO_IMAGE_NAME"
+          [ -n $ADDITIONAL_GHCR_IO_IMAGE_NAME ] && \
+          echo "ADDITIONAL_DOCKER_HUB_IMAGE_NAME  = $ADDITIONAL_DOCKER_HUB_IMAGE_NAME" && \
+          echo "ADDITIONAL_GHCR_IO_IMAGE_NAME     = $ADDITIONAL_GHCR_IO_IMAGE_NAME"
           echo "========================================="
 
       - name: Set up QEMU
@@ -128,22 +135,23 @@ jobs:
         with:
           version: latest
 
-      - name: Login to DockerHub
+      - name: Login to Github Container Registry
         uses: docker/login-action@v2.1.0
         with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PASS }}
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_IO_USER }}
+          password: ${{ secrets.GHCR_IO_PASS }}
 
       - name: Build and push multi-arch image
         run: |
           echo "Build and push $FINAL_IMAGE_NAME with version '$APP_VERSION'."
-          [ -n "$ADDITIONAL_IMAGE_NAME" ] && echo "Also push $ADDITIONAL_IMAGE_NAME."
+          [ -n "$ADDITIONAL_GHCR_IO_IMAGE_NAME" ] && echo "Also push $ADDITIONAL_GHCR_IO_IMAGE_NAME."
           echo
           docker buildx build \
             --platform $BUILDX_PLATFORMS \
             --build-arg appVersion=$APP_VERSION \
-            $( [ -n "$ADDITIONAL_IMAGE_NAME" ] && echo "--tag $ADDITIONAL_IMAGE_NAME" ) \
-            --tag $FINAL_IMAGE_NAME \
+            $( [ -n "$ADDITIONAL_GHCR_IO_IMAGE_NAME" ] && echo "--tag $ADDITIONAL_GHCR_IO_IMAGE_NAME" ) \
+            --tag $GHCR_IO_IMAGE_NAME \
             --push \
             .
 
@@ -151,14 +159,14 @@ jobs:
         run: |
           # Image for one arhitecture has digest in config field.
           # Image with multiple manifests has digest in each manifest.
-          manifests=$(docker buildx imagetools inspect "${FINAL_IMAGE_NAME}" --raw)
+          manifests=$(docker buildx imagetools inspect "${GHCR_IO_IMAGE_NAME}" --raw)
           if grep manifests <<<"${manifests}" 2>&1 >/dev/null ; then
             jq -r '.manifests[]? | .digest + " " + .platform.os + "/" + .platform.architecture' <<<"${manifests}"
           else
             echo $(echo -n "${manifests}" | openssl dgst -sha256 | sed s/^.stdin.*\ //) ' linux/amd64'
           fi \
           | while read digest platform ; do
-            image=$FINAL_IMAGE_NAME@${digest}
+            image=${GHCR_IO_IMAGE_NAME}@${digest}
             echo "====================================="
             echo "Inspect image for platform ${platform}"
             echo "  ${image}"
@@ -166,3 +174,33 @@ jobs:
             docker run --rm --platform ${platform} --entrypoint sh ${image} -c \
               'apk add file > /dev/null; file /bin/kubectl; file /bin/busybox; file /shell-operator'
           done
+
+      - name: Copy image to Docker Hub
+        env:
+          DOCKER_USER: ${{ secrets.DOCKER_USER }}
+          DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
+        run: |
+          echo "Copy ${GHCR_IO_IMAGE_NAME} to ${DOCKER_HUB_IMAGE_NAME} ..."
+          docker run \
+            -e "DOCKER_USER=${DOCKER_USER}" \
+            -e "DOCKER_PASS=${DOCKER_PASS}" \
+            -e "GHCR_IO_IMAGE_NAME=${GHCR_IO_IMAGE_NAME}" \
+            -e "DOCKER_HUB_IMAGE_NAME=${DOCKER_HUB_IMAGE_NAME}" \
+            quay.io/skopeo/stable:latest \
+              copy --all \
+              --dest-creds ${DOCKER_USER}:${DOCKER_PASS} \
+              docker://${GHCR_IO_IMAGE_NAME} \
+              docker://${DOCKER_HUB_IMAGE_NAME}
+
+          [ -n "$ADDITIONAL_DOCKER_HUB_IMAGE_NAME" ] && \
+          echo "Copy ${ADDITIONAL_GHCR_IO_IMAGE_NAME} to ${ADDITIONAL_DOCKER_HUB_IMAGE_NAME} ..." && \
+          docker run \
+            -e "DOCKER_USER=${DOCKER_USER}" \
+            -e "DOCKER_PASS=${DOCKER_PASS}" \
+            -e "GHCR_IO_IMAGE_NAME=${ADDITIONAL_GHCR_IO_IMAGE_NAME}" \
+            -e "DOCKER_HUB_IMAGE_NAME=${ADDITIONAL_DOCKER_HUB_IMAGE_NAME}" \
+            quay.io/skopeo/stable:latest \
+              copy --all \
+              --dest-creds ${DOCKER_USER}:${DOCKER_PASS} \
+              docker://${GHCR_IO_IMAGE_NAME} \
+              docker://${DOCKER_HUB_IMAGE_NAME}

--- a/README.md
+++ b/README.md
@@ -81,12 +81,12 @@ Make the `pods-hook.sh` executable:
 chmod +x pods-hook.sh
 ```
 
-You can use a prebuilt image [flant/shell-operator:latest](https://hub.docker.com/r/flant/shell-operator) with `bash`, `kubectl`, `jq` and `shell-operator` binaries to build you own image. You just need to `ADD` your hook into `/hooks` directory in the `Dockerfile`.
+You can use a prebuilt image [ghcr.io/flant/shell-operator:latest](https://github.com/flant/shell-operator/pkgs/container/shell-operator) with `bash`, `kubectl`, `jq` and `shell-operator` binaries to build you own image. You just need to `ADD` your hook into `/hooks` directory in the `Dockerfile`.
 
 Create the following `Dockerfile` in the directory where you created the `pods-hook.sh` file:
 
 ```dockerfile
-FROM flant/shell-operator:latest
+FROM ghcr.io/flant/shell-operator:latest
 ADD pods-hook.sh /hooks
 ```
 

--- a/RUNNING.md
+++ b/RUNNING.md
@@ -4,7 +4,8 @@
 
 ### Run in a cluster
 
-- Build an image from flant/shell-operator:v1.2.0, copy your hooks to `/hooks` directory.
+- Build an image from ghcr.io/flant/shell-operator:latest (or use a specific tag).
+- Copy your hooks to `/hooks` directory.
 - Apply RBAC manifests.
 - Apply Pod or Deployment manifest with the built image.
 

--- a/examples/001-startup-shell/Dockerfile
+++ b/examples/001-startup-shell/Dockerfile
@@ -1,2 +1,2 @@
-FROM flant/shell-operator:latest
+FROM ghcr.io/flant/shell-operator:latest
 ADD hooks /hooks

--- a/examples/002-startup-python/Dockerfile
+++ b/examples/002-startup-python/Dockerfile
@@ -1,3 +1,3 @@
-FROM flant/shell-operator:latest
+FROM ghcr.io/flant/shell-operator:latest
 RUN apk --no-cache add python3
 ADD hooks /hooks

--- a/examples/003-common-library/Dockerfile
+++ b/examples/003-common-library/Dockerfile
@@ -1,2 +1,2 @@
-FROM flant/shell-operator:latest
+FROM ghcr.io/flant/shell-operator:latest
 ADD hooks /hooks

--- a/examples/101-monitor-pods/Dockerfile
+++ b/examples/101-monitor-pods/Dockerfile
@@ -1,2 +1,2 @@
-FROM flant/shell-operator:latest
+FROM ghcr.io/flant/shell-operator:latest
 ADD hooks /hooks

--- a/examples/102-monitor-namespaces/Dockerfile
+++ b/examples/102-monitor-namespaces/Dockerfile
@@ -1,2 +1,2 @@
-FROM flant/shell-operator:latest
+FROM ghcr.io/flant/shell-operator:latest
 ADD hooks /hooks

--- a/examples/103-schedule/Dockerfile
+++ b/examples/103-schedule/Dockerfile
@@ -1,2 +1,2 @@
-FROM flant/shell-operator:latest
+FROM ghcr.io/flant/shell-operator:latest
 ADD hooks /hooks

--- a/examples/104-secret-copier/Dockerfile
+++ b/examples/104-secret-copier/Dockerfile
@@ -1,2 +1,2 @@
-FROM flant/shell-operator:latest
+FROM ghcr.io/flant/shell-operator:latest
 ADD hooks /hooks

--- a/examples/105-crd-simple/Dockerfile
+++ b/examples/105-crd-simple/Dockerfile
@@ -1,2 +1,2 @@
-FROM flant/shell-operator:latest
+FROM ghcr.io/flant/shell-operator:latest
 ADD hooks /hooks

--- a/examples/106-monitor-events/Dockerfile
+++ b/examples/106-monitor-events/Dockerfile
@@ -1,2 +1,2 @@
-FROM flant/shell-operator:latest
+FROM ghcr.io/flant/shell-operator:latest
 ADD hooks /hooks

--- a/examples/200-advanced/Dockerfile
+++ b/examples/200-advanced/Dockerfile
@@ -1,2 +1,2 @@
-FROM flant/shell-operator:latest
+FROM ghcr.io/flant/shell-operator:latest
 ADD hooks /hooks

--- a/examples/201-install-with-helm-chart/README.md
+++ b/examples/201-install-with-helm-chart/README.md
@@ -1,6 +1,6 @@
 ## example with helm chart
 
-A helm version of [102-monitor-namespaces](https://github.com/flant/shell-operator/tree/master/examples/102-monitor-namespaces) example. It uses `flant/shell-operator:latest` image in chart template to run shell-operator and a ConfigMap as a storage for hooks.
+A helm version of [102-monitor-namespaces](https://github.com/flant/shell-operator/tree/master/examples/102-monitor-namespaces) example. It uses `ghcr.io/flant/shell-operator:latest` image in chart template to run shell-operator and a ConfigMap as a storage for hooks.
 
 
 ### Run

--- a/examples/201-install-with-helm-chart/templates/shell-operator-deployment.yaml
+++ b/examples/201-install-with-helm-chart/templates/shell-operator-deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: shell-operator
-        image: "flant/shell-operator:latest"
+        image: "ghcr.io/flant/shell-operator:latest"
         imagePullPolicy: Always
         volumeMounts:
         - name: example-helm-hooks

--- a/examples/202-repack-build/Dockerfile
+++ b/examples/202-repack-build/Dockerfile
@@ -1,4 +1,4 @@
-FROM flant/shell-operator:v1.0.0-beta.14 as shell-operator
+FROM ghcr.io/flant/shell-operator:latest as shell-operator
 
 # Final image with kubectl 1.17 and curl
 FROM ubuntu:20.04

--- a/examples/204-validating-webhook/Dockerfile
+++ b/examples/204-validating-webhook/Dockerfile
@@ -1,4 +1,4 @@
-FROM flant/shell-operator:latest
+FROM ghcr.io/flant/shell-operator:latest
 LABEL app="shell-operator" example="204-validating-webhook"
 
 # Add hooks

--- a/examples/206-mutating-webhook/Dockerfile
+++ b/examples/206-mutating-webhook/Dockerfile
@@ -1,4 +1,4 @@
-FROM flant/shell-operator:latest
+FROM ghcr.io/flant/shell-operator:latest
 LABEL app="shell-operator" example="206-mutating-webhook"
 
 # Add hooks

--- a/examples/210-conversion-webhook/Dockerfile
+++ b/examples/210-conversion-webhook/Dockerfile
@@ -1,4 +1,4 @@
-FROM flant/shell-operator:latest
+FROM ghcr.io/flant/shell-operator:latest
 LABEL app="shell-operator" example="210-conversion-webhook"
 
 # Add hooks

--- a/examples/220-execution-rate/Dockerfile
+++ b/examples/220-execution-rate/Dockerfile
@@ -1,4 +1,4 @@
-FROM flant/shell-operator:latest
+FROM ghcr.io/flant/shell-operator:latest
 LABEL app="shell-operator" example="220-execution-rate"
 
 # Add hooks


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->


This PR is a reaction to recent Docker, Inc. actions: send [notification](https://www.docker.com/blog/we-apologize-we-did-a-terrible-job-announcing-the-end-of-docker-free-teams/) and then [apologize](https://www.docker.com/blog/we-apologize-we-did-a-terrible-job-announcing-the-end-of-docker-free-teams/) about free team accounts deletion. This may affect our docker hub account in the futute.
- This PR adds second image storage ghcr.io (Github Container Registry) to improve reliability.
- Release workflow still pushes latest images to dockerhub in addition to gchr.io.
- Some recent tags have been copied from https://hub.docker.com/r/flant/shell-operator to https://github.com/flant/shell-operator/pkgs/container/shell-operator/versions?filters%5Bversion_type%5D=tagged
- This PR prepend ghcr.io/ in all Dockerfiles and in md files.
- Users relying on flant/shell-operator images are advised to migrate to ghcr.io/flant/shell-operator in near future.
- Drawback: no badge for ghcr.io on shields.io (https://github.com/badges/shields/issues/5594)
