### PR TITLE
fix: MutatingWebhook - Snapshots not being added

### DIFF
--- a/pkg/hook/config/config_v1.go
+++ b/pkg/hook/config/config_v1.go
@@ -297,6 +297,15 @@ func (cv1 *HookConfigV1) ConvertAndCheck(c *HookConfig) (err error) {
 	}
 	c.KubernetesValidating = newValidating
 
+	newMutating := make([]MutatingConfig, 0)
+	for _, cfg := range c.KubernetesMutating {
+		if snapshots, ok := groupSnapshots[cfg.Group]; ok {
+			cfg.IncludeSnapshotsFrom = MergeArrays(cfg.IncludeSnapshotsFrom, snapshots)
+		}
+		newMutating = append(newMutating, cfg)
+	}
+	c.KubernetesMutating = newMutating
+
 	newConversion := make([]ConversionConfig, 0)
 	for _, cfg := range c.KubernetesConversion {
 		if snapshots, ok := groupSnapshots[cfg.Group]; ok {

--- a/pkg/hook/controller/hook_controller.go
+++ b/pkg/hook/controller/hook_controller.go
@@ -324,6 +324,13 @@ func (hc *hookController) getIncludeSnapshotsFrom(bindingType BindingType, bindi
 				break
 			}
 		}
+	case KubernetesMutating:
+		for _, binding := range hc.mutatingBindings {
+			if bindingName == binding.BindingName {
+				includeSnapshotsFrom = binding.IncludeSnapshotsFrom
+				break
+			}
+		}
 	case KubernetesConversion:
 		for _, binding := range hc.conversionBindings {
 			if bindingName == binding.BindingName {


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

When we specify values for `includeSnapshotsFrom:` and `group:` in the `KubernetesMutating` binding, the snapshots from the other bindings referenced are not added to the binding-context of `"type": "Mutating"`. The `snapshots: {}` field is empty.

#### What this PR does / why we need it

This PR resolves the issue above. The snapshots accumulated from the `group:` and `includeSnapshotsFrom:` keys are added to the mutatingConfig. This is also propagated to the `KubernetesMutating` binding and the binding-context.

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note

```