### PR TITLE
Adding single line output for base64

### DIFF
--- a/examples/206-mutating-webhook/hooks/mutating.sh
+++ b/examples/206-mutating-webhook/hooks/mutating.sh
@@ -27,7 +27,8 @@ function __main__() {
 #  echo "Got image: $image"
 
 #  if [[ $image == repo.example.com* ]] ; then
-  PATCH=$( echo '[{"op": "add", "path": "/spec/replicas", "value": 333 }]' | base64 )
+  # we need to have base64 output in one line, otherwise PATCH operation will not work
+  PATCH=$( echo '[{"op": "add", "path": "/spec/replicas", "value": 333 }]' | base64 -w 0 )
     cat <<EOF > $VALIDATING_RESPONSE_PATH
 {"allowed":true, "patch": "$PATCH"}
 EOF


### PR DESCRIPTION
#### Overview

When you have a bigger operation to patch, base64 will return output in multiple lines.

This will cause an error:
```
Error: got bad validating response: invalid character '\\n' in string literal
```

Which is hard to diagnose. Only having base64 output in oneliner makes it work correctly.

#### What this PR does / why we need it

I wasted a few hours debugging that issue and it was caused by base64. I think it will help others when they will be working on the examples.

#### Special notes for your reviewer

none :)