### PR TITLE
chore(go): Fix race conditions

### DIFF
--- a/pkg/kube_events_manager/kube_events_manager.go
+++ b/pkg/kube_events_manager/kube_events_manager.go
@@ -3,6 +3,7 @@ package kube_events_manager
 import (
 	"context"
 	"runtime/trace"
+	"sync"
 
 	log "github.com/sirupsen/logrus"
 
@@ -27,8 +28,6 @@ type KubeEventsManager interface {
 
 // kubeEventsManager is a main implementation of KubeEventsManager.
 type kubeEventsManager struct {
-	// Array of monitors
-	Monitors map[string]Monitor
 	// channel to emit KubeEvent objects
 	KubeEventCh chan KubeEvent
 
@@ -37,6 +36,9 @@ type kubeEventsManager struct {
 	ctx           context.Context
 	cancel        context.CancelFunc
 	metricStorage *metric_storage.MetricStorage
+
+	m        sync.RWMutex
+	Monitors map[string]Monitor
 }
 
 // kubeEventsManager should implement KubeEventsManager.
@@ -45,6 +47,7 @@ var _ KubeEventsManager = &kubeEventsManager{}
 // NewKubeEventsManager returns an implementation of KubeEventsManager.
 var NewKubeEventsManager = func() *kubeEventsManager {
 	em := &kubeEventsManager{
+		m:           sync.RWMutex{},
 		Monitors:    make(map[string]Monitor),
 		KubeEventCh: make(chan KubeEvent, 1),
 	}
@@ -83,34 +86,46 @@ func (mgr *kubeEventsManager) AddMonitor(monitorConfig *MonitorConfig) error {
 		return err
 	}
 
+	mgr.m.Lock()
 	mgr.Monitors[monitorConfig.Metadata.MonitorId] = monitor
+	mgr.m.Unlock()
 
 	return nil
 }
 
 // HasMonitor returns true if there is a monitor with monitorID.
 func (mgr *kubeEventsManager) HasMonitor(monitorID string) bool {
+	mgr.m.RLock()
 	_, has := mgr.Monitors[monitorID]
+	mgr.m.RUnlock()
 	return has
 }
 
 // GetMonitor returns monitor by its ID.
 func (mgr *kubeEventsManager) GetMonitor(monitorID string) Monitor {
+	mgr.m.RLock()
+	defer mgr.m.RUnlock()
 	return mgr.Monitors[monitorID]
 }
 
 // StartMonitor starts all informers for the monitor.
 func (mgr *kubeEventsManager) StartMonitor(monitorID string) {
+	mgr.m.RLock()
 	monitor := mgr.Monitors[monitorID]
+	mgr.m.RUnlock()
 	monitor.Start(mgr.ctx)
 }
 
 // StopMonitor stops monitor and removes it from the index.
 func (mgr *kubeEventsManager) StopMonitor(monitorID string) error {
+	mgr.m.RLock()
 	monitor, ok := mgr.Monitors[monitorID]
+	mgr.m.RUnlock()
 	if ok {
 		monitor.Stop()
+		mgr.m.Lock()
 		delete(mgr.Monitors, monitorID)
+		mgr.m.Unlock()
 	}
 	return nil
 }
@@ -124,6 +139,8 @@ func (mgr *kubeEventsManager) Ch() chan KubeEvent {
 // Useful for shutdown without panicking.
 // Calling cancel() leads to a race and panicking, see https://github.com/kubernetes/kubernetes/issues/59822
 func (mgr *kubeEventsManager) PauseHandleEvents() {
+	mgr.m.RLock()
+	defer mgr.m.RUnlock()
 	for _, monitor := range mgr.Monitors {
 		monitor.PauseHandleEvents()
 	}

--- a/pkg/task/queue/queue_set.go
+++ b/pkg/task/queue/queue_set.go
@@ -13,14 +13,15 @@ const MainQueueName = "main"
 
 // TaskQueueSet is a manager for a set of named queues
 type TaskQueueSet struct {
-	Queues   map[string]*TaskQueue
 	MainName string
 
 	metricStorage *metric_storage.MetricStorage
 
-	m      sync.Mutex
 	ctx    context.Context
 	cancel context.CancelFunc
+
+	m      sync.Mutex
+	Queues map[string]*TaskQueue
 }
 
 func NewTaskQueueSet() *TaskQueueSet {
@@ -69,7 +70,9 @@ func (tqs *TaskQueueSet) NewNamedQueue(name string, handler func(task.Task) Task
 	q.WithHandler(handler)
 	q.WithContext(tqs.ctx)
 	q.WithMetricStorage(tqs.metricStorage)
+	tqs.m.Lock()
 	tqs.Queues[name] = q
+	tqs.m.Unlock()
 }
 
 func (tqs *TaskQueueSet) GetByName(name string) *TaskQueue {

--- a/test/integration/kubeclient/kube_client_test.go
+++ b/test/integration/kubeclient/kube_client_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"testing"
 
+	. "github.com/flant/shell-operator/test/integration/suite"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
Fix a couple of race conditions:

```
WARNING: DATA RACE
Write at 0x00c000da9860 by main goroutine:
  runtime.mapassign_faststr()
      /usr/local/go/src/runtime/map_faststr.go:203 +0x0
  github.com/flant/shell-operator/pkg/task/queue.(*TaskQueueSet).NewNamedQueue()
      /go/pkg/mod/github.com/flant/shell-operator@v1.2.0/pkg/task/queue/queue_set.go:72 +0x22b

Previous read at 0x00c000da9860 by goroutine 63:
  github.com/flant/shell-operator/pkg/task/queue.(*TaskQueueSet).Iterate()
      /go/pkg/mod/github.com/flant/shell-operator@v1.2.0/pkg/task/queue/queue_set.go:108 +0xe8
```
----
```
WARNING: DATA RACE
Read at 0x00c000da98f0 by goroutine 935:
  runtime.mapaccess2_faststr()
      /usr/local/go/src/runtime/map_faststr.go:108 +0x0
  github.com/flant/shell-operator/pkg/kube_events_manager.(*kubeEventsManager).HasMonitor()
      /go/pkg/mod/github.com/flant/shell-operator@v1.2.0/pkg/kube_events_manager/kube_events_manager.go:93 +0x56
  github.com/flant/shell-operator/pkg/hook/controller.(*kubernetesBindingsController).SnapshotsFor()
      /go/pkg/mod/github.com/flant/shell-operator@v1.2.0/pkg/hook/controller/kubernetes_bindings_controller.go:218 +0x185
  github.com/flant/shell-operator/pkg/hook/controller.(*hookController).UpdateSnapshots()
      /go/pkg/mod/github.com/flant/shell-operator@v1.2.0/pkg/hook/controller/hook_controller.go:366 +0x666

Previous write at 0x00c000da98f0 by goroutine 66:
  runtime.mapassign_faststr()
      /usr/local/go/src/runtime/map_faststr.go:203 +0x0
  github.com/flant/shell-operator/pkg/kube_events_manager.(*kubeEventsManager).AddMonitor()
      /go/pkg/mod/github.com/flant/shell-operator@v1.2.0/pkg/kube_events_manager/kube_events_manager.go:86 +0x267
  github.com/flant/shell-operator/pkg/hook/controller.(*kubernetesBindingsController).EnableKubernetesBindings()
      /go/pkg/mod/github.com/flant/shell-operator@v1.2.0/pkg/hook/controller/kubernetes_bindings_controller.go:78 +0x1bc
  github.com/flant/shell-operator/pkg/hook/controller.(*hookController).HandleEnableKubernetesBindings()
      /go/pkg/mod/github.com/flant/shell-operator@v1.2.0/pkg/hook/controller/hook_controller.go:186 +0x7c
```
