### PR TITLE
Add verbosity if FilterFunction contains an error

### DIFF
--- a/pkg/kube_events_manager/filter.go
+++ b/pkg/kube_events_manager/filter.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
+	"runtime"
 	"runtime/trace"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -30,7 +32,7 @@ func ApplyFilter(jqFilter string, filterFn func(obj *unstructured.Unstructured) 
 	if filterFn != nil {
 		filteredObj, err := filterFn(obj)
 		if err != nil {
-			return nil, fmt.Errorf("filterFn: %v", err)
+			return nil, fmt.Errorf("filterFn (%s) contains an error: %v", runtime.FuncForPC(reflect.ValueOf(filterFn).Pointer()).Name(), err)
 		}
 
 		filteredBytes, err := json.Marshal(filteredObj)

--- a/pkg/kube_events_manager/filter_test.go
+++ b/pkg/kube_events_manager/filter_test.go
@@ -1,0 +1,26 @@
+package kube_events_manager
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestApplyFilter(t *testing.T) {
+	t.Run("filter func with error", func(t *testing.T) {
+		uns := &unstructured.Unstructured{Object: map[string]interface{}{"foo": "bar"}}
+		_, err := ApplyFilter("", filterFuncWithError, uns)
+		assert.EqualError(t, err, "filterFn (github.com/flant/shell-operator/pkg/kube_events_manager.filterFuncWithError) contains an error: invalid character 'a' looking for beginning of value")
+	})
+}
+
+func filterFuncWithError(_ *unstructured.Unstructured) (result interface{}, err error) {
+	var s []string
+
+	err = json.Unmarshal([]byte("asdasd"), &s)
+
+	return s, err
+}

--- a/pkg/kube_events_manager/filter_test.go
+++ b/pkg/kube_events_manager/filter_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 

--- a/test/integration/kubeclient/kube_client_test.go
+++ b/test/integration/kubeclient/kube_client_test.go
@@ -7,10 +7,11 @@ import (
 	"context"
 	"testing"
 
-	. "github.com/flant/shell-operator/test/integration/suite"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/flant/shell-operator/test/integration/suite"
 )
 
 func Test(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Add function name to the output for FilterFunc error.

#### What this PR does / why we need it

It's hard to understand, which function generated an error in the runtime, especially if we have a few hooks in a module. With this change we can easily locate problem function and fix it.

#### Special notes for your reviewer

Now we have an error like:
```
"filterFn: invalid character 'a' looking for beginning of value"
```

new signature is:
```
"filterFn (github.com/flant/shell-operator/pkg/kube_events_manager.filterFuncWithError) contains an error: invalid character 'a' looking for beginning of value"
```