### PR TITLE
✨ feat: Accessing old object on `watchEvent`

### DIFF
--- a/docs/src/KUBERNETES.md
+++ b/docs/src/KUBERNETES.md
@@ -12,11 +12,11 @@ The path to the file is found in the `$KUBERNETES_PATCH_PATH` environment variab
 ### Create
 
 * `operation` — specifies an operation's type.
-    * `CreateOrUpdate` — accept a Kubernetes object.
+  * `CreateOrUpdate` — accept a Kubernetes object.
       It retrieves an object, and if it already exists, computes a JSON Merge Patch and applies it (will not update .status field).
       If it does not exist, we create the object.
-    * `Create` — will fail if an object already exists
-    * `CreateIfNotExists` — create an object if such an object does not already
+  * `Create` — will fail if an object already exists
+  * `CreateIfNotExists` — create an object if such an object does not already
       exist by namespace/name.
 * `object` — full object specification including "apiVersion", "kind" and all necessary metadata. Can be a normal JSON or YAML object or a stringified JSON or YAML object.
 
@@ -25,6 +25,54 @@ The path to the file is found in the `$KUBERNETES_PATCH_PATH` environment variab
 ```json
 {
   "operation": "CreateOrUpdate",
+  "oldObject": {
+    "apiVersion": "apps/v1",
+    "kind": "DaemonSet",
+    "metadata": {
+      "name": "flannel",
+      "namespace": "d8-flannel"
+    },
+    "spec": {
+      "selector": {
+        "matchLabels": {
+          "app": "flannel"
+        }
+      },
+      "template": {
+        "metadata": {
+          "labels": {
+            "app": "flannel",
+            "tier": "old-node"
+          }
+        },
+        "spec": {
+          "containers": [
+            {
+              "args": [
+                "--ip-masq",
+                "--kube-subnet-mgr"
+              ],
+              "image": "flannel:v0.11",
+              "name": "kube-flannel",
+              "securityContext": {
+                "privileged": true
+              }
+            }
+          ],
+          "hostNetwork": true,
+          "imagePullSecrets": [
+            {
+              "name": "registry"
+            }
+          ],
+          "terminationGracePeriodSeconds": 5
+        }
+      },
+      "updateStrategy": {
+        "type": "RollingUpdate"
+      }
+    }
+  },
   "object": {
     "apiVersion": "apps/v1",
     "kind": "DaemonSet",
@@ -123,7 +171,7 @@ object: |
 
 ### Patch
 
-Use `JQPatch` for almost everything. Consider using `MergePatch` or `JSONPatch` if you are attempting to modify 
+Use `JQPatch` for almost everything. Consider using `MergePatch` or `JSONPatch` if you are attempting to modify
 rapidly changing object, for example `status` field with many concurrent changes (and incrementing `resourceVersion`).
 
 Be careful, when updating a `.status` field. If a `/status` subresource is enabled on a resource,
@@ -140,6 +188,7 @@ More info [here][spec-and-status].
 * `name` — object's name.
 * `jqFilter` — describes transformations to perform on an object.
 * `subresource` — a subresource name if subresource is to be transformed. For example, `status`.
+
 ##### Example
 
 ```json

--- a/pkg/kube_events_manager/types/types.go
+++ b/pkg/kube_events_manager/types/types.go
@@ -41,6 +41,7 @@ type ObjectAndFilterResult struct {
 		RemoveObject bool
 	}
 	Object       *unstructured.Unstructured // here is a pointer because of MarshalJSON receiver
+	OldObject    *unstructured.Unstructured // here is a pointer because of MarshalJSON receiver and also it's nullable for some events
 	FilterResult interface{}
 }
 


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

By using OldObject input from K8s we will have access to oldObject when modified

#### What this PR does / why we need it

Closes #515
I need this here: https://github.com/mhkarimi1383/reflector/pull/3

Sometimes we need to have access to older object specially if we are managing our own CRD
<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer
