### PR TITLE
[deckhouse] Start HTTP API debug server if "DebugHttpPort" is set.

### DIFF
--- a/pkg/app/debug.go
+++ b/pkg/app/debug.go
@@ -8,6 +8,8 @@ import (
 
 var DebugUnixSocket = "/var/run/shell-operator/debug.socket"
 
+var DebugHttpPort = ""
+
 var DebugKeepTmpFiles = "no"
 
 var DebugKubernetesAPI = false
@@ -74,4 +76,12 @@ func DefineDebugUnixSocketFlag(cmd *kingpin.CmdClause) {
 		Hidden().
 		Default(DebugUnixSocket).
 		StringVar(&DebugUnixSocket)
+}
+
+func DefineDebugHttpPortFlag(cmd *kingpin.CmdClause) {
+	cmd.Flag("debug-http-port", "http port for a debug endpoint").
+		Envar("DEBUG_HTTP_PORT").
+		Hidden().
+		Default(DebugHttpPort).
+		StringVar(&DebugHttpPort)
 }

--- a/pkg/app/debug.go
+++ b/pkg/app/debug.go
@@ -8,7 +8,7 @@ import (
 
 var DebugUnixSocket = "/var/run/shell-operator/debug.socket"
 
-var DebugHttpPort = ""
+var DebugHttpServerAddr = ""
 
 var DebugKeepTmpFiles = "no"
 
@@ -80,8 +80,8 @@ func DefineDebugUnixSocketFlag(cmd *kingpin.CmdClause) {
 
 func DefineDebugHttpPortFlag(cmd *kingpin.CmdClause) {
 	cmd.Flag("debug-http-port", "http port for a debug endpoint").
-		Envar("DEBUG_HTTP_PORT").
+		Envar("DEBUG_HTTP_SERVER_ADDR").
 		Hidden().
-		Default(DebugHttpPort).
-		StringVar(&DebugHttpPort)
+		Default(DebugHttpServerAddr).
+		StringVar(&DebugHttpServerAddr)
 }

--- a/pkg/debug/server.go
+++ b/pkg/debug/server.go
@@ -76,7 +76,6 @@ func (s *Server) Init() (err error) {
 	}()
 
 	if s.HttpAddr != "" {
-
 		go func() {
 			if err := http.ListenAndServe(s.HttpAddr, s.Router); err != nil {
 				log.Errorf("Error starting Debug HTTP server: %s", err)

--- a/pkg/debug/server.go
+++ b/pkg/debug/server.go
@@ -20,6 +20,7 @@ import (
 type Server struct {
 	SocketPath string
 	Prefix     string
+	HttpPort   string
 
 	Router chi.Router
 }
@@ -34,6 +35,10 @@ func (s *Server) WithSocketPath(path string) {
 
 func (s *Server) WithPrefix(prefix string) {
 	s.Prefix = prefix
+}
+
+func (s *Server) WithHttpPort(port string) {
+	s.HttpPort = port
 }
 
 func (s *Server) Init() (err error) {
@@ -73,10 +78,21 @@ func (s *Server) Init() (err error) {
 
 	go func() {
 		if err := http.Serve(listener, s.Router); err != nil {
-			log.Errorf("Error starting Debug HTTP server: %s", err)
+			log.Errorf("Error starting Debug socket server: %s", err)
 			os.Exit(1)
 		}
 	}()
+
+	if s.HttpPort != "" {
+		port := fmt.Sprintf("127.0.0.1:%s", s.HttpPort)
+
+		go func() {
+			if err := http.ListenAndServe(port, s.Router); err != nil {
+				log.Errorf("Error starting Debug HTTP server: %s", err)
+				os.Exit(1)
+			}
+		}()
+	}
 
 	return nil
 }

--- a/pkg/debug/server.go
+++ b/pkg/debug/server.go
@@ -20,16 +20,16 @@ import (
 type Server struct {
 	Prefix     string
 	SocketPath string
-	HttpPort   string
+	HttpAddr   string
 
 	Router chi.Router
 }
 
-func NewServer(prefix, socketPath, httpPort string) *Server {
+func NewServer(prefix, socketPath, httpAddr string) *Server {
 	return &Server{
 		Prefix:     prefix,
 		SocketPath: socketPath,
-		HttpPort:   httpPort,
+		HttpAddr:   httpAddr,
 	}
 }
 
@@ -75,11 +75,10 @@ func (s *Server) Init() (err error) {
 		}
 	}()
 
-	if s.HttpPort != "" {
-		port := fmt.Sprintf("127.0.0.1:%s", s.HttpPort)
+	if s.HttpAddr != "" {
 
 		go func() {
-			if err := http.ListenAndServe(port, s.Router); err != nil {
+			if err := http.ListenAndServe(s.HttpAddr, s.Router); err != nil {
 				log.Errorf("Error starting Debug HTTP server: %s", err)
 				os.Exit(1)
 			}

--- a/pkg/debug/server.go
+++ b/pkg/debug/server.go
@@ -18,27 +18,19 @@ import (
 )
 
 type Server struct {
-	SocketPath string
 	Prefix     string
+	SocketPath string
 	HttpPort   string
 
 	Router chi.Router
 }
 
-func NewServer() *Server {
-	return &Server{}
-}
-
-func (s *Server) WithSocketPath(path string) {
-	s.SocketPath = path
-}
-
-func (s *Server) WithPrefix(prefix string) {
-	s.Prefix = prefix
-}
-
-func (s *Server) WithHttpPort(port string) {
-	s.HttpPort = port
+func NewServer(prefix, socketPath, httpPort string) *Server {
+	return &Server{
+		Prefix:     prefix,
+		SocketPath: socketPath,
+		HttpPort:   httpPort,
+	}
 }
 
 func (s *Server) Init() (err error) {

--- a/pkg/shell-operator/debug_server.go
+++ b/pkg/shell-operator/debug_server.go
@@ -18,6 +18,7 @@ func DefaultDebugServer() *debug.Server {
 	dbgSrv := debug.NewServer()
 	dbgSrv.WithPrefix("/debug")
 	dbgSrv.WithSocketPath(app.DebugUnixSocket)
+	dbgSrv.WithHttpPort(app.DebugHttpPort)
 	return dbgSrv
 }
 

--- a/pkg/shell-operator/debug_server.go
+++ b/pkg/shell-operator/debug_server.go
@@ -15,7 +15,7 @@ import (
 )
 
 func DefaultDebugServer() *debug.Server {
-	dbgSrv := debug.NewServer("/debug", app.DebugUnixSocket, app.DebugHttpPort)
+	dbgSrv := debug.NewServer("/debug", app.DebugUnixSocket, app.DebugHttpServerAddr)
 
 	return dbgSrv
 }

--- a/pkg/shell-operator/debug_server.go
+++ b/pkg/shell-operator/debug_server.go
@@ -15,10 +15,8 @@ import (
 )
 
 func DefaultDebugServer() *debug.Server {
-	dbgSrv := debug.NewServer()
-	dbgSrv.WithPrefix("/debug")
-	dbgSrv.WithSocketPath(app.DebugUnixSocket)
-	dbgSrv.WithHttpPort(app.DebugHttpPort)
+	dbgSrv := debug.NewServer("/debug", app.DebugUnixSocket, app.DebugHttpPort)
+
 	return dbgSrv
 }
 


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Deckhouse has an API that provides info on the state of its internal storage, queues, preflight patches, and more.
This API is now exposed via the Unix socket and can be accessed with the deckhouse-controller CLI.
#### What this PR does / why we need it

Added an HTTP API server on localhost next to the socket server if "DebugHttpPort" is set.

#### Special notes for your reviewer

We want to make it public and secure in deckhouse using kube-rbac-proxy.