### PR TITLE
[deckhouse] Fix using debug flag "debug-http-addr".

### DIFF
--- a/pkg/app/debug.go
+++ b/pkg/app/debug.go
@@ -18,6 +18,12 @@ var DebugKubernetesAPI = false
 func DefineDebugFlags(kpApp *kingpin.Application, cmd *kingpin.CmdClause) {
 	DefineDebugUnixSocketFlag(cmd)
 
+	cmd.Flag("debug-http-addr", "http addr for a debug endpoint").
+		Envar("DEBUG_HTTP_SERVER_ADDR").
+		Hidden().
+		Default(DebugHttpServerAddr).
+		StringVar(&DebugHttpServerAddr)
+
 	cmd.Flag("debug-keep-tmp-files", "set to yes to disable cleanup of temporary files").
 		Envar("DEBUG_KEEP_TMP_FILES").
 		Hidden().
@@ -76,12 +82,4 @@ func DefineDebugUnixSocketFlag(cmd *kingpin.CmdClause) {
 		Hidden().
 		Default(DebugUnixSocket).
 		StringVar(&DebugUnixSocket)
-}
-
-func DefineDebugHttpPortFlag(cmd *kingpin.CmdClause) {
-	cmd.Flag("debug-http-port", "http port for a debug endpoint").
-		Envar("DEBUG_HTTP_SERVER_ADDR").
-		Hidden().
-		Default(DebugHttpServerAddr).
-		StringVar(&DebugHttpServerAddr)
 }


### PR DESCRIPTION
#### Overview

Deckhouse has an API that provides info on the state of its internal storage, queues, preflight patches, and more.
This API is now exposed via the Unix socket and can be accessed with the deckhouse-controller CLI.

#### What this PR does / why we need it

Fix using debug flag "debug-http-addr".

#### Special notes for your reviewer

During manual testing, the required flags were read in the "addon-operator". For this reason no error was detected.
