### PR TITLE
add IgnoreHookError patch option

### DIFF
--- a/pkg/kube/object_patch/operation.go
+++ b/pkg/kube/object_patch/operation.go
@@ -57,7 +57,6 @@ func GetPatchStatusOperationsOnHookError(operations []Operation) []Operation {
 			if operation.subresource == "/status" && operation.ignoreHookError {
 				patchStatusOperations = append(patchStatusOperations, operation)
 			}
-		default:
 		}
 	}
 

--- a/pkg/kube/object_patch/options.go
+++ b/pkg/kube/object_patch/options.go
@@ -45,8 +45,29 @@ func (s *subresourceHolder) applyToFilter(operation *filterOperation) {
 	operation.subresource = s.subresource
 }
 
+type ignoreHookError struct {
+	ignoreError bool
+}
+
+// IgnoreHookError allows applying patches for a Status subresource even if the hook fails
+func IgnoreHookError() *ignoreHookError {
+	return WithIgnoreHookError(true)
+}
+
+func WithIgnoreHookError(ignoreError bool) *ignoreHookError {
+	return &ignoreHookError{ignoreError: ignoreError}
+}
+
 type ignoreMissingObject struct {
 	ignore bool
+}
+
+func (i *ignoreHookError) applyToPatch(operation *patchOperation) {
+	operation.ignoreHookError = i.ignoreError
+}
+
+func (i *ignoreHookError) applyToFilter(operation *filterOperation) {
+	operation.ignoreHookError = i.ignoreError
 }
 
 // IgnoreMissingObject do not return error if object exists for Patch and Filter operations.

--- a/pkg/kube/object_patch/patch.go
+++ b/pkg/kube/object_patch/patch.go
@@ -152,6 +152,7 @@ func (o *ObjectPatcher) executeCreateOperation(op *createOperation) error {
 // Other options:
 // - WithSubresource — a subresource argument for Patch or Update API call.
 // - IgnoreMissingObject — do not return error if the specified object is missing.
+// - IgnoreHookError — allows applying patches for a Status subresource even if the hook fails
 func (o *ObjectPatcher) executePatchOperation(op *patchOperation) error {
 	if op.patchType == types.MergePatchType {
 		log.Debug("Started MergePatchObject")
@@ -190,6 +191,11 @@ func (o *ObjectPatcher) executePatchOperation(op *patchOperation) error {
 
 // executeFilterOperation retrieves a specified object, modified it with
 // filterFunc and calls update.
+
+// Other options:
+// - WithSubresource — a subresource argument for Patch or Update API call.
+// - IgnoreMissingObject — do not return error if the specified object is missing.
+// - IgnoreHookError — allows applying patches for a Status subresource even if the hook fails
 func (o *ObjectPatcher) executeFilterOperation(op *filterOperation) error {
 	var err error
 

--- a/pkg/kube/object_patch/patch_collector.go
+++ b/pkg/kube/object_patch/patch_collector.go
@@ -43,6 +43,7 @@ func (dop *PatchCollector) Delete(apiVersion, kind, namespace, name string, opti
 // Options:
 //   - WithSubresource — a subresource argument for Patch call.
 //   - IgnoreMissingObject — do not return error if the specified object is missing.
+//   - IgnoreHookError — allows applying patches for a Status subresource even if the hook fails
 func (dop *PatchCollector) MergePatch(mergePatch interface{}, apiVersion, kind, namespace, name string, options ...PatchOption) {
 	dop.add(NewMergePatchOperation(mergePatch, apiVersion, kind, namespace, name, options...))
 }
@@ -52,6 +53,7 @@ func (dop *PatchCollector) MergePatch(mergePatch interface{}, apiVersion, kind, 
 // Options:
 //   - WithSubresource — a subresource argument for Patch call.
 //   - IgnoreMissingObject — do not return error if the specified object is missing.
+//   - IgnoreHookError — allows applying patches for a Status subresource even if the hook fails
 func (dop *PatchCollector) JSONPatch(jsonPatch interface{}, apiVersion, kind, namespace, name string, options ...PatchOption) {
 	dop.add(NewJSONPatchOperation(jsonPatch, apiVersion, kind, namespace, name, options...))
 }
@@ -62,6 +64,7 @@ func (dop *PatchCollector) JSONPatch(jsonPatch interface{}, apiVersion, kind, na
 // Options:
 //   - WithSubresource — a subresource argument for Patch call.
 //   - IgnoreMissingObject — do not return error if the specified object is missing.
+//   - IgnoreHookError — allows applying patches for a Status subresource even if the hook fails
 //
 // Note: do not modify and return argument in filterFunc,
 // use FromUnstructured to instantiate a concrete type or modify after DeepCopy.

--- a/pkg/kube/object_patch/validation.go
+++ b/pkg/kube/object_patch/validation.go
@@ -56,6 +56,8 @@ definitions:
         type: string
       ignoreMissingObject:
         type: boolean
+      ignoreHookError:
+        type: boolean
 
 type: object
 additionalProperties: false
@@ -71,6 +73,7 @@ properties:
   jqFilter: {}
   mergePatch: {}
   ignoreMissingObject: {}
+  ignoreHookError: {}
 
 oneOf:
 - allOf:


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview
This PR adds additional patch_option for Filter/Patch operations named `IgnoreHookError` and some execution logic around it.
<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it
If `IgnoreHookError` is set to true for a Filter/Patch operation and `WithSubresource` equals to `/status`, such an operation will be applied even in case of the hook failure.
It can come in handy in a situation when a hook operates around some kubernetes resource and one wants to make it more obvious when the resource was noticied/processed/etc by the hook last time by means of status fields.

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
This way we could provide some meaningful statuses or a feedback loop on what  happens when a hook is executed.
#### Special notes for your reviewer
