### PR TITLE
Handle empty config hook section

### DIFF
--- a/pkg/hook/hook_manager.go
+++ b/pkg/hook/hook_manager.go
@@ -208,6 +208,10 @@ func (hm *hookManager) loadHook(hookPath string) (hook *Hook, err error) {
 	hook.WithHookController(hookCtrl)
 	hook.WithTmpDir(hm.TempDir())
 
+	if hook.Config == nil {
+		return nil, fmt.Errorf("hook %q is marked as executable but doesn't contain config section", hook.Path)
+	}
+
 	hookEntry.Infof("Loaded config: %s", hook.GetConfigDescription())
 
 	return hook, nil


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Handle shell hooks without config section

#### What this PR does / why we need it

If executable hook doesn't have `config` section, shell-operator will panic. We need to handle this situation and throw an understandable error

#### Special notes for your reviewer
