### PR TITLE
Ignore some file extensions

### DIFF
--- a/pkg/utils/file/file.go
+++ b/pkg/utils/file/file.go
@@ -47,6 +47,12 @@ func RecursiveGetExecutablePaths(dir string) ([]string, error) {
 			return nil
 		}
 
+		// ignore .yaml, .json, .txt, .md files
+		switch filepath.Ext(f.Name()) {
+		case ".yaml", ".json", ".md", ".txt":
+			return nil
+		}
+
 		if !IsFileExecutable(f) {
 			log.Warnf("File '%s' is skipped: no executable permissions, chmod +x is required to run this hook", path)
 			return nil


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Ignore 100% non-executable hook files

#### What this PR does / why we need it

With this files we can get some weird message about non-executable yaml file. I think we can absolutely ignore them.

#### Special notes for your reviewer

`.yaml`, `.json`, `.md` and `.txt` could not be executable hooks anymore
