### PR TITLE
Separate metric storages

### DIFF
--- a/pkg/hook/controller/kubernetes_bindings_controller.go
+++ b/pkg/hook/controller/kubernetes_bindings_controller.go
@@ -155,6 +155,10 @@ func (c *kubernetesBindingsController) UnlockEvents() {
 // UnlockEventsFor turns on eventCb for matched monitor to emit events after Synchronization.
 func (c *kubernetesBindingsController) UnlockEventsFor(monitorID string) {
 	m := c.kubeEventsManager.GetMonitor(monitorID)
+	if m == nil {
+		log.Warnf("monitor %q was not found", monitorID)
+		return
+	}
 	m.EnableKubeEventCb()
 }
 

--- a/pkg/shell-operator/bootstrap.go
+++ b/pkg/shell-operator/bootstrap.go
@@ -119,8 +119,6 @@ func (op *ShellOperator) assembleShellOperator(hooksDir string, tempDir string, 
 	op.RegisterDebugHookRoutes(debugServer)
 	op.RegisterDebugConfigRoutes(debugServer, runtimeConfig)
 
-	registerShellOperatorMetrics(op.MetricStorage)
-
 	// Create webhookManagers with dependencies.
 	op.setupHookManagers(hooksDir, tempDir)
 

--- a/pkg/shell-operator/bootstrap.go
+++ b/pkg/shell-operator/bootstrap.go
@@ -111,7 +111,9 @@ func (op *ShellOperator) AssembleCommonOperator(listenAddress, listenPort string
 //   - kubernetes events manager
 //   - schedule manager
 func (op *ShellOperator) assembleShellOperator(hooksDir string, tempDir string, debugServer *debug.Server, runtimeConfig *config.Config) (err error) {
-	registerDefaultRoutes(op)
+	registerRootRoute(op)
+	// for shell-operator only
+	registerHookMetrics(op.HookMetricStorage)
 
 	op.RegisterDebugQueueRoutes(debugServer)
 	op.RegisterDebugHookRoutes(debugServer)

--- a/pkg/shell-operator/http_server.go
+++ b/pkg/shell-operator/http_server.go
@@ -109,7 +109,7 @@ func newBaseHTTPServer(address, port string) *baseHTTPServer {
 	return srv
 }
 
-func registerDefaultRoutes(op *ShellOperator) {
+func registerRootRoute(op *ShellOperator) {
 	op.APIServer.RegisterRoute(http.MethodGet, "/", func(writer http.ResponseWriter, request *http.Request) {
 		_, _ = fmt.Fprintf(writer, `<html>
   <head><title>Shell operator</title></head>
@@ -124,11 +124,5 @@ func registerDefaultRoutes(op *ShellOperator) {
     </dl>
   </body>
 </html>`, app.ListenPort)
-	})
-
-	op.APIServer.RegisterRoute(http.MethodGet, "/metrics", func(writer http.ResponseWriter, request *http.Request) {
-		if op.MetricStorage != nil {
-			op.MetricStorage.Handler().ServeHTTP(writer, request)
-		}
 	})
 }

--- a/pkg/shell-operator/http_server.go
+++ b/pkg/shell-operator/http_server.go
@@ -27,8 +27,8 @@ func (bhs *baseHTTPServer) Start(ctx context.Context) {
 	srv := &http.Server{
 		Addr:         bhs.address + ":" + bhs.port,
 		Handler:      bhs.router,
-		ReadTimeout:  30 * time.Second,
-		WriteTimeout: 30 * time.Second,
+		ReadTimeout:  90 * time.Second,
+		WriteTimeout: 90 * time.Second,
 	}
 
 	go func() {

--- a/pkg/shell-operator/metrics_hooks.go
+++ b/pkg/shell-operator/metrics_hooks.go
@@ -10,8 +10,73 @@ import (
 func (op *ShellOperator) setupHookMetricStorage() {
 	metricStorage := metric_storage.NewMetricStorage(op.ctx, app.PrometheusMetricsPrefix, true)
 
+	registerHookMetrics(metricStorage)
+
 	op.APIServer.RegisterRoute(http.MethodGet, "/metrics/hooks", metricStorage.Handler().ServeHTTP)
 	// create new metric storage for hooks
 	// register scrape handler
-	op.MetricStorage = metricStorage
+	op.HookMetricStorage = metricStorage
+}
+
+// specific metrics for HookManager
+func registerHookMetrics(metricStorage *metric_storage.MetricStorage) {
+	// Metrics for enable kubernetes bindings.
+	metricStorage.RegisterGauge("{PREFIX}hook_enable_kubernetes_bindings_seconds", map[string]string{"hook": ""})
+	metricStorage.RegisterCounter("{PREFIX}hook_enable_kubernetes_bindings_errors_total", map[string]string{"hook": ""})
+	metricStorage.RegisterGauge("{PREFIX}hook_enable_kubernetes_bindings_success", map[string]string{"hook": ""})
+
+	// Metrics for hook executions.
+	labels := map[string]string{
+		"hook":    "",
+		"binding": "",
+		"queue":   "",
+	}
+	// Duration of hook execution.
+	metricStorage.RegisterHistogram(
+		"{PREFIX}hook_run_seconds",
+		labels,
+		[]float64{
+			0.0,
+			0.02, 0.05, // 20,50 milliseconds
+			0.1, 0.2, 0.5, // 100,200,500 milliseconds
+			1, 2, 5, // 1,2,5 seconds
+			10, 20, 50, // 10,20,50 seconds
+			100, 200, 500, // 100,200,500 seconds
+		},
+	)
+
+	// System CPU usage.
+	metricStorage.RegisterHistogram(
+		"{PREFIX}hook_run_user_cpu_seconds",
+		labels,
+		[]float64{
+			0.0,
+			0.02, 0.05, // 20,50 milliseconds
+			0.1, 0.2, 0.5, // 100,200,500 milliseconds
+			1, 2, 5, // 1,2,5 seconds
+			10, 20, 50, // 10,20,50 seconds
+			100, 200, 500, // 100,200,500 seconds
+		},
+	)
+	// User CPU usage.
+	metricStorage.RegisterHistogram(
+		"{PREFIX}hook_run_sys_cpu_seconds",
+		labels,
+		[]float64{
+			0.0,
+			0.02, 0.05, // 20,50 milliseconds
+			0.1, 0.2, 0.5, // 100,200,500 milliseconds
+			1, 2, 5, // 1,2,5 seconds
+			10, 20, 50, // 10,20,50 seconds
+			100, 200, 500, // 100,200,500 seconds
+		},
+	)
+	// Max RSS in bytes.
+	metricStorage.RegisterGauge("{PREFIX}hook_run_max_rss_bytes", labels)
+
+	metricStorage.RegisterCounter("{PREFIX}hook_run_errors_total", labels)
+	metricStorage.RegisterCounter("{PREFIX}hook_run_allowed_errors_total", labels)
+	metricStorage.RegisterCounter("{PREFIX}hook_run_success_total", labels)
+	// hook_run task waiting time
+	metricStorage.RegisterCounter("{PREFIX}task_wait_in_queue_seconds_total", labels)
 }

--- a/pkg/shell-operator/metrics_hooks.go
+++ b/pkg/shell-operator/metrics_hooks.go
@@ -10,15 +10,13 @@ import (
 func (op *ShellOperator) setupHookMetricStorage() {
 	metricStorage := metric_storage.NewMetricStorage(op.ctx, app.PrometheusMetricsPrefix, true)
 
-	registerHookMetrics(metricStorage)
-
 	op.APIServer.RegisterRoute(http.MethodGet, "/metrics/hooks", metricStorage.Handler().ServeHTTP)
 	// create new metric storage for hooks
 	// register scrape handler
 	op.HookMetricStorage = metricStorage
 }
 
-// specific metrics for HookManager
+// specific metrics for shell-operator HookManager
 func registerHookMetrics(metricStorage *metric_storage.MetricStorage) {
 	// Metrics for enable kubernetes bindings.
 	metricStorage.RegisterGauge("{PREFIX}hook_enable_kubernetes_bindings_seconds", map[string]string{"hook": ""})

--- a/pkg/shell-operator/metrics_operator.go
+++ b/pkg/shell-operator/metrics_operator.go
@@ -1,22 +1,32 @@
 package shell_operator
 
 import (
-	"context"
+	"net/http"
 
 	"github.com/flant/shell-operator/pkg/app"
 	"github.com/flant/shell-operator/pkg/metric_storage"
 )
 
-func defaultMetricStorage(ctx context.Context) *metric_storage.MetricStorage {
-	metricStorage := metric_storage.NewMetricStorage(ctx, app.PrometheusMetricsPrefix, false)
-	return metricStorage
+// setupMetricStorage creates and initializes metrics storage for built-in operator metrics
+func (op *ShellOperator) setupMetricStorage(kubeEventsManagerLabels map[string]string) {
+	metricStorage := metric_storage.NewMetricStorage(op.ctx, app.PrometheusMetricsPrefix, false)
+
+	registerCommonMetrics(metricStorage)
+	registerTaskQueueMetrics(metricStorage)
+	registerKubeEventsManagerMetrics(metricStorage, kubeEventsManagerLabels)
+	registerHookMetrics(metricStorage)
+
+	op.APIServer.RegisterRoute(http.MethodGet, "/metrics", metricStorage.Handler().ServeHTTP)
+	// create new metric storage for hooks
+	// register scrape handler
+	op.MetricStorage = metricStorage
 }
 
 // registerShellOperatorMetrics register all metrics needed for the ShellOperator.
 func registerShellOperatorMetrics(metricStorage *metric_storage.MetricStorage) {
-	RegisterCommonMetrics(metricStorage)
-	RegisterTaskQueueMetrics(metricStorage)
-	RegisterKubeEventsManagerMetrics(metricStorage, map[string]string{
+	registerCommonMetrics(metricStorage)
+	registerTaskQueueMetrics(metricStorage)
+	registerKubeEventsManagerMetrics(metricStorage, map[string]string{
 		"hook":    "",
 		"binding": "",
 		"queue":   "",
@@ -24,15 +34,15 @@ func registerShellOperatorMetrics(metricStorage *metric_storage.MetricStorage) {
 	registerHookMetrics(metricStorage)
 }
 
-// RegisterCommonMetrics register base metric
+// registerCommonMetrics register base metric
 // This function is used in the addon-operator
-func RegisterCommonMetrics(metricStorage *metric_storage.MetricStorage) {
+func registerCommonMetrics(metricStorage *metric_storage.MetricStorage) {
 	metricStorage.RegisterCounter("{PREFIX}live_ticks", map[string]string{})
 }
 
-// RegisterTaskQueueMetrics
+// registerTaskQueueMetrics
 // This function is used in the addon-operator
-func RegisterTaskQueueMetrics(metricStorage *metric_storage.MetricStorage) {
+func registerTaskQueueMetrics(metricStorage *metric_storage.MetricStorage) {
 	metricStorage.RegisterHistogram(
 		"{PREFIX}tasks_queue_action_duration_seconds",
 		map[string]string{
@@ -51,9 +61,9 @@ func RegisterTaskQueueMetrics(metricStorage *metric_storage.MetricStorage) {
 	metricStorage.RegisterGauge("{PREFIX}tasks_queue_length", map[string]string{"queue": ""})
 }
 
-// RegisterKubeEventsManagerMetrics registers metrics for kube_event_manager
+// registerKubeEventsManagerMetrics registers metrics for kube_event_manager
 // This function is used in the addon-operator
-func RegisterKubeEventsManagerMetrics(metricStorage *metric_storage.MetricStorage, labels map[string]string) {
+func registerKubeEventsManagerMetrics(metricStorage *metric_storage.MetricStorage, labels map[string]string) {
 	// Count of objects in snapshot for one kubernets bindings.
 	metricStorage.RegisterGauge("{PREFIX}kube_snapshot_objects", labels)
 	// Duration of jqFilter applying.
@@ -83,67 +93,4 @@ func RegisterKubeEventsManagerMetrics(metricStorage *metric_storage.MetricStorag
 
 	// Count of watch errors.
 	metricStorage.RegisterCounter("{PREFIX}kubernetes_client_watch_errors_total", map[string]string{"error_type": ""})
-}
-
-// Shell-operator specific metrics for HookManager
-func registerHookMetrics(metricStorage *metric_storage.MetricStorage) {
-	// Metrics for enable kubernetes bindings.
-	metricStorage.RegisterGauge("{PREFIX}hook_enable_kubernetes_bindings_seconds", map[string]string{"hook": ""})
-	metricStorage.RegisterCounter("{PREFIX}hook_enable_kubernetes_bindings_errors_total", map[string]string{"hook": ""})
-	metricStorage.RegisterGauge("{PREFIX}hook_enable_kubernetes_bindings_success", map[string]string{"hook": ""})
-
-	// Metrics for hook executions.
-	labels := map[string]string{
-		"hook":    "",
-		"binding": "",
-		"queue":   "",
-	}
-	// Duration of hook execution.
-	metricStorage.RegisterHistogram(
-		"{PREFIX}hook_run_seconds",
-		labels,
-		[]float64{
-			0.0,
-			0.02, 0.05, // 20,50 milliseconds
-			0.1, 0.2, 0.5, // 100,200,500 milliseconds
-			1, 2, 5, // 1,2,5 seconds
-			10, 20, 50, // 10,20,50 seconds
-			100, 200, 500, // 100,200,500 seconds
-		},
-	)
-
-	// System CPU usage.
-	metricStorage.RegisterHistogram(
-		"{PREFIX}hook_run_user_cpu_seconds",
-		labels,
-		[]float64{
-			0.0,
-			0.02, 0.05, // 20,50 milliseconds
-			0.1, 0.2, 0.5, // 100,200,500 milliseconds
-			1, 2, 5, // 1,2,5 seconds
-			10, 20, 50, // 10,20,50 seconds
-			100, 200, 500, // 100,200,500 seconds
-		},
-	)
-	// User CPU usage.
-	metricStorage.RegisterHistogram(
-		"{PREFIX}hook_run_sys_cpu_seconds",
-		labels,
-		[]float64{
-			0.0,
-			0.02, 0.05, // 20,50 milliseconds
-			0.1, 0.2, 0.5, // 100,200,500 milliseconds
-			1, 2, 5, // 1,2,5 seconds
-			10, 20, 50, // 10,20,50 seconds
-			100, 200, 500, // 100,200,500 seconds
-		},
-	)
-	// Max RSS in bytes.
-	metricStorage.RegisterGauge("{PREFIX}hook_run_max_rss_bytes", labels)
-
-	metricStorage.RegisterCounter("{PREFIX}hook_run_errors_total", labels)
-	metricStorage.RegisterCounter("{PREFIX}hook_run_allowed_errors_total", labels)
-	metricStorage.RegisterCounter("{PREFIX}hook_run_success_total", labels)
-	// hook_run task waiting time
-	metricStorage.RegisterCounter("{PREFIX}task_wait_in_queue_seconds_total", labels)
 }

--- a/pkg/shell-operator/metrics_operator.go
+++ b/pkg/shell-operator/metrics_operator.go
@@ -14,24 +14,11 @@ func (op *ShellOperator) setupMetricStorage(kubeEventsManagerLabels map[string]s
 	registerCommonMetrics(metricStorage)
 	registerTaskQueueMetrics(metricStorage)
 	registerKubeEventsManagerMetrics(metricStorage, kubeEventsManagerLabels)
-	registerHookMetrics(metricStorage)
 
 	op.APIServer.RegisterRoute(http.MethodGet, "/metrics", metricStorage.Handler().ServeHTTP)
 	// create new metric storage for hooks
 	// register scrape handler
 	op.MetricStorage = metricStorage
-}
-
-// registerShellOperatorMetrics register all metrics needed for the ShellOperator.
-func registerShellOperatorMetrics(metricStorage *metric_storage.MetricStorage) {
-	registerCommonMetrics(metricStorage)
-	registerTaskQueueMetrics(metricStorage)
-	registerKubeEventsManagerMetrics(metricStorage, map[string]string{
-		"hook":    "",
-		"binding": "",
-		"queue":   "",
-	})
-	registerHookMetrics(metricStorage)
 }
 
 // registerCommonMetrics register base metric

--- a/pkg/shell-operator/operator.go
+++ b/pkg/shell-operator/operator.go
@@ -37,8 +37,9 @@ type ShellOperator struct {
 	// APIServer common http server for liveness and metrics endpoints
 	APIServer *baseHTTPServer
 
+	// MetricStorage collects and store metrics for built-in operator primitives, hook execution
 	MetricStorage *metric_storage.MetricStorage
-	// separate metric storage for hook metrics if separate listen port is configured
+	// HookMetricStorage separate metric storage for metrics, which are returned by user hooks
 	HookMetricStorage *metric_storage.MetricStorage
 	KubeClient        *klient.Client
 	ObjectPatcher     *object_patch.ObjectPatcher


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

- Separate `HookMetricStorage` and `MetricStorage`
  - `MetricStorage` collects base go metrics and shell-opertor built-in metrics and returns on `/metrics`
  - `HookMetricStorage` collects metrics from user hooks and returns on `/metrics/hooks`
- Increase HTTP Server timeouts

#### What this PR does / why we need it

Separate base metrics from hook metrics

#### Special notes for your reviewer
