### PR TITLE
Update apiVersions in the crd-simple example

### DIFF
--- a/examples/105-crd-simple/crd-simple.yaml
+++ b/examples/105-crd-simple/crd-simple.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
@@ -6,13 +6,6 @@ metadata:
 spec:
   # group name to use for REST API: /apis/<group>/<version>
   group: stable.example.com
-  # list of versions supported by this CustomResourceDefinition
-  versions:
-    - name: v1
-      # Each version can be enabled/disabled by Served flag.
-      served: true
-      # One and only one version must be marked as the storage version.
-      storage: true
   # either Namespaced or Cluster
   scope: Namespaced
   names:
@@ -26,17 +19,23 @@ spec:
     shortNames:
     - ct
     #  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      type: object
-      properties:
-        spec:
+  # list of versions supported by this CustomResourceDefinition
+  versions:
+    - name: v1
+      # Each version can be enabled/disabled by Served flag.
+      served: true
+      # One and only one version must be marked as the storage version.
+      storage: true
+      schema:
+        openAPIV3Schema:
           type: object
           properties:
-            cronSpec:
-              type: string
-            image:
-              type: string
-            replicas:
-              type: integer
-
+            spec:
+              type: object
+              properties:
+                cronSpec:
+                  type: string
+                image:
+                  type: string
+                replicas:
+                  type: integer

--- a/examples/105-crd-simple/shell-operator-rbac.yaml
+++ b/examples/105-crd-simple/shell-operator-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   name: crd-simple-acc
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: crd-simple
@@ -15,7 +15,7 @@ rules:
   verbs: ["get", "watch", "list"]
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: crd-simple


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Update apiVersions in the crd-simple example

#### What this PR does / why we need it

Kubernetes 1.27 uses updated API versions of the following kinds:
- CustomResourceDefinition
- ClusterRole
- ClusterRoleBinding

Also, CustomResourceDefinition v1 has the updated schema.
