### PR TITLE
Improve the way of updating metrics collectors' labelsets

### DIFF
--- a/pkg/metric_storage/vault/vault.go
+++ b/pkg/metric_storage/vault/vault.go
@@ -41,7 +41,7 @@ func (v *GroupedVault) GetOrCreateCounterCollector(name string, labelNames []str
 			return nil, fmt.Errorf("counter '%s' %v registration: %v", name, labelNames, err)
 		}
 		v.collectors[name] = collector
-	} else if !LabelNamesEqual(collector.LabelNames(), labelNames) {
+	} else if !IsSubset(collector.LabelNames(), labelNames) {
 		collector.UpdateLabels(labelNames)
 	}
 	if counter, ok := collector.(*ConstCounterCollector); ok {
@@ -60,7 +60,7 @@ func (v *GroupedVault) GetOrCreateGaugeCollector(name string, labelNames []strin
 			return nil, fmt.Errorf("gauge '%s' %v registration: %v", name, labelNames, err)
 		}
 		v.collectors[name] = collector
-	} else if !LabelNamesEqual(collector.LabelNames(), labelNames) {
+	} else if !IsSubset(collector.LabelNames(), labelNames) {
 		collector.UpdateLabels(labelNames)
 	}
 

--- a/pkg/metric_storage/vault/vault_test.go
+++ b/pkg/metric_storage/vault/vault_test.go
@@ -123,6 +123,8 @@ metric2_total{lbl="val222"} 2
 	v.CounterAdd("group3", "metric_total4", 19.0, map[string]string{"c": "c2"})
 	v.CounterAdd("group3", "metric_total4", 29.0, map[string]string{})
 	v.CounterAdd("group3", "metric_total4", 39.0, map[string]string{"j": "j1"})
+	v.CounterAdd("group3", "metric_total4", 1.0, map[string]string{"j": "j1"})
+	v.CounterAdd("group3", "metric_total4", 1.0, map[string]string{"a": "", "b": "", "c": "", "d": "", "j": "j1"})
 
 	g.Expect(buf.String()).ShouldNot(ContainSubstring("error"), "error occurred in log: %s", buf.String())
 
@@ -148,7 +150,7 @@ metric_total4{a="", b="", c="", d="d1", j=""} 9
 metric_total4{a="a1", b="b1", c="c1", d="d1", j=""} 99
 metric_total4{a="", b="", c="c2", d="", j=""} 19
 metric_total4{a="", b="", c="", d="", j=""} 29
-metric_total4{a="", b="", c="", d="", j="j1"} 39
+metric_total4{a="", b="", c="", d="", j="j1"} 41
 `
 
 	err = promtest.GatherAndCompare(prometheus.DefaultGatherer, strings.NewReader(expect), "metric_total1", "metric_total2", "metric_total3", "metric_total4")

--- a/pkg/metric_storage/vault/vault_test.go
+++ b/pkg/metric_storage/vault/vault_test.go
@@ -118,6 +118,12 @@ metric2_total{lbl="val222"} 2
 	v.CounterAdd("group2", "metric_total3", 99.0, map[string]string{"lbl": "val222", "ord": "ord222"})
 	v.CounterAdd("group2", "metric_total3", 9.0, map[string]string{"lbl": "val222", "ord": "ord222"})
 
+	v.CounterAdd("group3", "metric_total4", 9.0, map[string]string{"d": "d1"})
+	v.CounterAdd("group3", "metric_total4", 99.0, map[string]string{"a": "a1", "b": "b1", "c": "c1", "d": "d1"})
+	v.CounterAdd("group3", "metric_total4", 19.0, map[string]string{"c": "c2"})
+	v.CounterAdd("group3", "metric_total4", 29.0, map[string]string{})
+	v.CounterAdd("group3", "metric_total4", 39.0, map[string]string{"j": "j1"})
+
 	g.Expect(buf.String()).ShouldNot(ContainSubstring("error"), "error occurred in log: %s", buf.String())
 
 	expect = `
@@ -136,8 +142,15 @@ metric_total2{a="A3", b="B3", c=""} 3
 metric_total3{lbl="val222", ord=""} 5
 metric_total3{lbl="", ord="ord222"} 10
 metric_total3{lbl="val222", ord="ord222"} 108
+# HELP metric_total4 metric_total4
+# TYPE metric_total4 counter
+metric_total4{a="", b="", c="", d="d1", j=""} 9
+metric_total4{a="a1", b="b1", c="c1", d="d1", j=""} 99
+metric_total4{a="", b="", c="c2", d="", j=""} 19
+metric_total4{a="", b="", c="", d="", j=""} 29
+metric_total4{a="", b="", c="", d="", j="j1"} 39
 `
 
-	err = promtest.GatherAndCompare(prometheus.DefaultGatherer, strings.NewReader(expect), "metric_total1", "metric_total2", "metric_total3")
+	err = promtest.GatherAndCompare(prometheus.DefaultGatherer, strings.NewReader(expect), "metric_total1", "metric_total2", "metric_total3", "metric_total4")
 	g.Expect(err).ShouldNot(HaveOccurred())
 }

--- a/pkg/utils/labels/labels.go
+++ b/pkg/utils/labels/labels.go
@@ -54,13 +54,15 @@ func DefaultIfEmpty(m map[string]string, def map[string]string) map[string]strin
 	return m
 }
 
-func LabelNamesEqual(a, b[]string) bool {
-	if len(a) != len(b) {
-		return false
+// IsSubset checks if a set contains b subset
+func IsSubset(a, b []string) bool {
+	aMap := make(map[string]struct{}, len(a))
+	for _, v := range a {
+		aMap[v] = struct{}{}
 	}
 
-	for i := range a {
-		if a[i] != b[i] {
+	for _, v := range b {
+		if _, found := aMap[v]; !found {
 			return false
 		}
 	}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview
The pr updates the way new labelset are applied to metrics collectors. Also, a collector is updated only if a new metric's labelset isn't a subset of the collector's labelset (there is/are new label(s) on the metric).

<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it
When a metric is saved, it is checked that the metric's labels are a subset of the corresponding collector (if there is any) and if it isn't the case, the collector's labelset and stored metrics' labelsets are updated according to a new labelset (previous labels plus new labels from the metric about to store).
New labelsets for metrics collectors are sorted before applying.
<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer
