### PR TITLE
[kube_events_manager] fix informer factory

### DIFF
--- a/pkg/kube_events_manager/factory.go
+++ b/pkg/kube_events_manager/factory.go
@@ -27,7 +27,6 @@ type FactoryIndex struct {
 	Namespace     string
 	FieldSelector string
 	LabelSelector string
-	MonitorId     string
 }
 
 type Factory struct {
@@ -62,6 +61,7 @@ func (c *FactoryStore) get(ctx context.Context, client dynamic.Interface, index 
 	f, ok := c.data[index]
 	if ok {
 		f.score++
+		c.data[index] = f
 		return f
 	}
 
@@ -122,7 +122,8 @@ func (c *FactoryStore) Stop(index FactoryIndex) {
 	f.score--
 	if f.score == 0 {
 		f.cancel()
+		delete(c.data, index)
 	}
 
-	delete(c.data, index)
+	c.data[index] = f
 }

--- a/pkg/kube_events_manager/factory.go
+++ b/pkg/kube_events_manager/factory.go
@@ -123,6 +123,7 @@ func (c *FactoryStore) Stop(index FactoryIndex) {
 	if f.score == 0 {
 		f.cancel()
 		delete(c.data, index)
+		return
 	}
 
 	c.data[index] = f

--- a/pkg/kube_events_manager/factory.go
+++ b/pkg/kube_events_manager/factory.go
@@ -27,6 +27,7 @@ type FactoryIndex struct {
 	Namespace     string
 	FieldSelector string
 	LabelSelector string
+	MonitorId     string
 }
 
 type Factory struct {

--- a/pkg/kube_events_manager/resource_informer.go
+++ b/pkg/kube_events_manager/resource_informer.go
@@ -127,7 +127,6 @@ func (ei *resourceInformer) createSharedInformer() (err error) {
 		Namespace:     ei.Namespace,
 		FieldSelector: ei.ListOptions.FieldSelector,
 		LabelSelector: ei.ListOptions.LabelSelector,
-		MonitorId:     ei.Monitor.Metadata.MonitorId,
 	}
 
 	err = ei.loadExistedObjects()

--- a/pkg/kube_events_manager/resource_informer.go
+++ b/pkg/kube_events_manager/resource_informer.go
@@ -127,6 +127,7 @@ func (ei *resourceInformer) createSharedInformer() (err error) {
 		Namespace:     ei.Namespace,
 		FieldSelector: ei.ListOptions.FieldSelector,
 		LabelSelector: ei.ListOptions.LabelSelector,
+		MonitorId:     ei.Monitor.Metadata.MonitorId,
 	}
 
 	err = ei.loadExistedObjects()


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

<!-- Describe your changes briefly here. -->
FactoryStore's get and Stop methods didn't save some modifications to the FactoryStore's map.

#### What this PR does / why we need it
FactoryStore's get and Stop methods didn't save some modifications to the FactoryStore's map which would result in having inconsistent factory storage, leading to stopping resource informers prematurely.

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer
