### PR TITLE
fix shell_lib regarding grouping

### DIFF
--- a/frameworks/shell/hook.sh
+++ b/frameworks/shell/hook.sh
@@ -46,7 +46,8 @@ function hook::_get_possible_handler_names() {
       esac
     ;;
     "Group")
-      echo __on_group::${BINDING_CONTEXT_CURRENT_BINDING}
+      BINDING_CONTEXT_GROUP_NAME=$(context::jq -er '.groupName')
+      echo __on_group::${BINDING_CONTEXT_GROUP_NAME}
     ;;
     "Schedule")
       echo __on_schedule::${BINDING_CONTEXT_CURRENT_BINDING}

--- a/pkg/hook/binding_context/binding_context.go
+++ b/pkg/hook/binding_context/binding_context.go
@@ -95,6 +95,7 @@ func (bc BindingContext) MapV1() map[string]interface{} {
 	// Group is always has "type: Group", even for Synchronization.
 	if bc.Metadata.Group != "" {
 		res["type"] = "Group"
+		res["groupName"] = bc.Metadata.Group
 		return res
 	}
 

--- a/pkg/hook/binding_context/binding_context_test.go
+++ b/pkg/hook/binding_context/binding_context_test.go
@@ -230,17 +230,19 @@ func Test_ConvertBindingContextList_v1(t *testing.T) {
 				g.Expect(bcList[0]).Should(HaveKey("binding"))
 				g.Expect(bcList[0]).Should(HaveKey("snapshots"))
 				g.Expect(bcList[0]).Should(HaveKey("type"))
+				g.Expect(bcList[0]).Should(HaveKey("groupName"))
 				g.Expect(bcList[0]).ShouldNot(HaveKey("objects"))
 			},
 			[][]string{
 				{`. | length`, `2`},
 
-				// grouped binding context contains binding, type and snapshots
-				{`.[0] | length`, `3`}, // Only 3 fields
+				// grouped binding context contains binding, type, snapshots and groupName
+				{`.[0] | length`, `4`}, // Only 4 fields
 				{`.[0].snapshots | has("monitor_pods")`, `true`},
 				{`.[0].snapshots."monitor_pods" | length`, `1`},
 				{`.[0].binding`, `"monitor_pods"`},
 				{`.[0].type`, `"Group"`},
+				{`.[0].groupName`, `"pods"`},
 
 				// JSON dump should has only 4 fields: binding, type, watchEvent and object.
 				{`.[1] | length`, `4`},
@@ -309,11 +311,12 @@ func Test_ConvertBindingContextList_v1(t *testing.T) {
 			func() {
 				g.Expect(bcList).Should(HaveLen(2))
 
-				g.Expect(bcList[0]).Should(HaveLen(3))
+				g.Expect(bcList[0]).Should(HaveLen(4))
 				g.Expect(bcList[0]).Should(HaveKey("binding"))
 				g.Expect(bcList[0]["binding"]).Should(Equal("monitor_config_maps"))
 				g.Expect(bcList[0]).Should(HaveKey("type"))
 				g.Expect(bcList[0]["type"]).Should(Equal("Group"))
+				g.Expect(bcList[0]["groupName"]).Should(Equal("pods"))
 				g.Expect(bcList[0]).Should(HaveKey("snapshots"))
 				g.Expect(bcList[0]["snapshots"]).Should(HaveLen(1))
 
@@ -327,8 +330,8 @@ func Test_ConvertBindingContextList_v1(t *testing.T) {
 			[][]string{
 				{`. | length`, `2`},
 
-				// grouped binding context contains binding==group, type and snapshots
-				{`.[0] | length`, `3`}, // Only 3 fields
+				// grouped binding context contains binging, type, snapshots and groupName
+				{`.[0] | length`, `4`}, // Only 4 fields
 				{`.[0].binding`, `"monitor_config_maps"`},
 				{`.[0].type`, `"Group"`},
 				{`.[0].snapshots | has("monitor_config_maps")`, `true`},


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview
Fixes mapping of grouped binding contexts to `on_group` handlers in the shell-lib.

<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it
Adds additional `.groupName` field  to a binding context conversion result which is used to map grouped binding contexts to a `on_group` handler.
Updates shell-lib to use new `groupName` binding context field when mapping events to handlers.
<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer
