### PR TITLE
[schedule-manager] fix entry clean-up

### DIFF
--- a/pkg/schedule_manager/schedule_manager.go
+++ b/pkg/schedule_manager/schedule_manager.go
@@ -104,6 +104,7 @@ func (sm *scheduleManager) Remove(delEntry ScheduleEntry) {
 	// if all ids are deleted, stop scheduled function
 	if len(sm.Entries[delEntry.Crontab].Ids) == 0 {
 		sm.cron.Remove(sm.Entries[delEntry.Crontab].EntryID)
+		delete(sm.Entries, delEntry.Crontab)
 		log.WithField("operator.component", "scheduleManager").Debugf("entry '%s' deleted", delEntry.Crontab)
 	}
 }


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

<!-- Describe your changes briefly here. -->
Updates the `schedule-manager`'s Remove method to clean-up an entry from the `Entries` map if there are no associated schedule bindings left with the entry. 
#### What this PR does / why we need it
It corrects the way schedule bindings of a module cleaned-up when the module is disabled. And, If the module is re-enabled, its schedule bindings are recreated correctly.
<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer
