### PR TITLE
Introducing Shell Operator on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 <p align="center">
 <a href="https://hub.docker.com/r/flant/shell-operator"><img src="https://img.shields.io/docker/pulls/flant/shell-operator.svg?logo=docker" alt="docker pull flant/shell-operator"/></a>
  <a href="https://github.com/flant/shell-operator/discussions"><img src="https://img.shields.io/badge/GitHub-discussions-brightgreen" alt="GH Discussions"/></a>
+  <a href="https://gurubase.io/g/shell-operator"><img src="https://img.shields.io/badge/Gurubase-Ask%20Shell%20Operator%20Guru-006BFF" alt="GH Discussions"/></a>
 </p>
 
 **Shell-operator** is a tool for running event-driven scripts in a Kubernetes cluster.


### PR DESCRIPTION
Hello 

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Shell Operator Guru](https://gurubase.io/g/shell-operator) to Gurubase. Shell Operator Guru uses the data from this repo and data from the [docs](https://flant.github.io/shell-operator/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Shell Operator Guru" badge, which highlights that Shell Operator now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Shell Operator Guru in Gurubase, just let me know that's totally fine.