### PR TITLE
Add a list of excluded paths when discovering executable files

### DIFF
--- a/pkg/utils/file/file.go
+++ b/pkg/utils/file/file.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
@@ -32,8 +33,9 @@ func CheckExecutablePermissions(f os.FileInfo) error {
 
 // RecursiveGetExecutablePaths finds recursively all executable files
 // inside a dir directory. Hidden directories and files are ignored.
-func RecursiveGetExecutablePaths(dir string) ([]string, error) {
+func RecursiveGetExecutablePaths(dir string, excludedDirs ...string) ([]string, error) {
 	paths := make([]string, 0)
+	excludedDirs = append(excludedDirs, "lib")
 	err := filepath.Walk(dir, func(path string, f os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -41,7 +43,7 @@ func RecursiveGetExecutablePaths(dir string) ([]string, error) {
 
 		if f.IsDir() {
 			// Skip hidden and lib directories inside initial directory
-			if strings.HasPrefix(f.Name(), ".") || f.Name() == "lib" {
+			if strings.HasPrefix(f.Name(), ".") || slices.Contains(excludedDirs, f.Name()) {
 				return filepath.SkipDir
 			}
 


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

Adds an optional argument `excludedDirs` to `RecursiveGetExecutablePaths` helper function so that it would be possible to define extra exclusions when discovering executable files.

It's required for https://github.com/flant/addon-operator/pull/571.

#### Overview

<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer
