### PR TITLE
Fix depricated `kubectl exec` command

### DIFF
--- a/docs/src/RUNNING.md
+++ b/docs/src/RUNNING.md
@@ -79,7 +79,7 @@ The following tools for debugging and fine-tuning of Shell-operator and hooks ar
 - The environment variable can be set to `LOG_LEVEL=debug` to include the detailed debugging information into logs,
 - You can view the contents of the working queues with cli command from inside a Pod:
    ```sh
-   kubectl exec -ti po/shell-operator /bin/bash
+   kubectl exec -ti po/shell-operator -- /bin/bash
    shell-operator queue list
    ```
 


### PR DESCRIPTION
#### Overview

In the docs used depricated kubectl command
```
kubectl exec -ti shell-operator /bin/bash
error: exec [POD] [COMMAND] is not supported anymore. Use exec [POD] -- [COMMAND] instead
See 'kubectl exec -h' for help and examples
```
