### PR TITLE
[shell-operator] add default group to every hook

### DIFF
--- a/pkg/hook/hook.go
+++ b/pkg/hook/hook.go
@@ -175,7 +175,7 @@ func (h *Hook) Run(ctx context.Context, _ htypes.BindingType, context []bctx.Bin
 		return result, fmt.Errorf("%s FAILED: %s", h.Name, err)
 	}
 
-	result.Metrics, err = operation.MetricOperationsFromFile(metricsPath)
+	result.Metrics, err = operation.MetricOperationsFromFile(metricsPath, h.Name)
 	if err != nil {
 		return result, fmt.Errorf("got bad metrics: %s", err)
 	}

--- a/pkg/metric_storage/operation/operation_test.go
+++ b/pkg/metric_storage/operation/operation_test.go
@@ -39,7 +39,7 @@ func Test_ValidateMetricOperations(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			ops, err := MetricOperationsFromBytes([]byte(tt.op))
+			ops, err := MetricOperationsFromBytes([]byte(tt.op), "")
 			g.Expect(err).ShouldNot(HaveOccurred())
 
 			err = ValidateOperations(ops)

--- a/pkg/metric_storage/vault/vault.go
+++ b/pkg/metric_storage/vault/vault.go
@@ -68,9 +68,11 @@ func (v *GroupedVault) GetOrCreateCounterCollector(name string, labelNames []str
 	} else if !IsSubset(collector.LabelNames(), labelNames) {
 		collector.UpdateLabels(labelNames)
 	}
+
 	if counter, ok := collector.(*metric.ConstCounterCollector); ok {
 		return counter, nil
 	}
+
 	return nil, fmt.Errorf("counter %v collector requested, but %s %v collector exists", labelNames, collector.Type(), collector.LabelNames())
 }
 
@@ -99,9 +101,17 @@ func (v *GroupedVault) CounterAdd(group string, name string, value float64, labe
 	metricName := v.resolveMetricNameFunc(name)
 	c, err := v.GetOrCreateCounterCollector(metricName, LabelNames(labels))
 	if err != nil {
-		log.Error("CounterAdd", log.Err(err))
+		log.Error(
+			"CounterAdd",
+			slog.String("group", group),
+			slog.String("name", name),
+			slog.Any("labels", labels),
+			log.Err(err),
+		)
+
 		return
 	}
+
 	c.Add(group, value, labels)
 }
 
@@ -119,5 +129,6 @@ func (v *GroupedVault) GaugeSet(group string, name string, value float64, labels
 
 		return
 	}
+
 	c.Set(group, value, labels)
 }

--- a/pkg/metric_storage/vault/vault.go
+++ b/pkg/metric_storage/vault/vault.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"fmt"
+	"log/slog"
 	"sync"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
@@ -108,7 +109,14 @@ func (v *GroupedVault) GaugeSet(group string, name string, value float64, labels
 	metricName := v.resolveMetricNameFunc(name)
 	c, err := v.GetOrCreateGaugeCollector(metricName, LabelNames(labels))
 	if err != nil {
-		log.Error("GaugeSet", log.Err(err))
+		log.Error(
+			"GaugeSet",
+			slog.String("group", group),
+			slog.String("name", name),
+			slog.Any("labels", labels),
+			log.Err(err),
+		)
+
 		return
 	}
 	c.Set(group, value, labels)


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

The previous behavior for hook execution had inconsistent metric handling that could lead to metric accumulation between hook runs.

<!-- Describe your changes briefly here. -->

## What this PR does / why we need it

### Previous Behavior

When executing hooks, metrics were collected as-is without consistent grouping:
- ✅ If grouping was explicitly specified in the hook → metrics were grouped accordingly
- ❌ If no grouping was specified → metrics were saved without any grouping
- ⚠️ **Issue**: This behavior caused metrics to persist between hook executions, leading to potential data accumulation and inconsistency

### New Behavior

The implementation now ensures consistent metric lifecycle management:
- 🔄 **All metrics without explicit grouping are automatically grouped by hook name**
- 📝 **Hook naming convention**: Derived from file path
  - Example: `hooks/100-hook/some-hook.go` → Hook name: `100-hook/somehook`
- 🧹 **Automatic cleanup**: When new metrics arrive from a hook execution:
  - Old metrics are automatically expired (cleaned from storage)
  - New metrics from the current hook execution replace the old ones

#### Benefits

- **Consistent metric lifecycle**: No more metric accumulation between runs
- **Automatic cleanup**: Storage is kept clean without manual intervention  
- **Predictable behavior**: Every hook execution has a fresh metric state
- **Default grouping**: Eliminates ungrouped metrics that could cause confusion

#### Implementation Details

- Metrics are automatically grouped by hook name when no explicit grouping is provided
- Each hook execution triggers cleanup of previous metrics before storing new ones

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

## Special notes for your reviewer
