### PR TITLE
[shell-operator] Add curl support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN GOOS=linux \
 # Final image
 FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine:3.21
 ARG TARGETPLATFORM
-RUN apk --no-cache add ca-certificates bash sed tini && \
+RUN apk --no-cache add ca-certificates bash sed tini curl && \
     kubectlArch=$(echo ${TARGETPLATFORM:-linux/amd64} | sed 's/\/v7//') && \
     echo "Download kubectl for ${kubectlArch}" && \
     wget https://dl.k8s.io/release/v1.30.12/bin/${kubectlArch}/kubectl -O /bin/kubectl && \


### PR DESCRIPTION
#### Overview

This PR adds curl support to the shell-operator.

#### What this PR does / why we need it

Add the `curl` package to the Alpine base image in the main Dockerfile.

- Users can make HTTP requests from hooks out of the box
- No more need for custom images just for basic networking tools
- All existing functionality remains unchanged
