### PR TITLE
[chore] add typed error for executor

### DIFF
--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -32,6 +32,16 @@ func Run(cmd *exec.Cmd) error {
 	return cmd.Run()
 }
 
+// StderrError is returned by RunAndLogLines when a command fails and produces
+// output on stderr. Callers can use errors.As to access the raw stderr content.
+type StderrError struct {
+	Stderr string
+}
+
+func (e *StderrError) Error() string {
+	return fmt.Sprintf("stderr: %s", e.Stderr)
+}
+
 type Executor struct {
 	cmd              *exec.Cmd
 	logProxyHookJSON bool
@@ -147,7 +157,7 @@ func (e *Executor) RunAndLogLines(ctx context.Context, logLabels map[string]stri
 	err := e.cmd.Run()
 	if err != nil {
 		if len(stdErr.Bytes()) > 0 {
-			return nil, fmt.Errorf("stderr: %s", stdErr.String())
+			return nil, &StderrError{Stderr: stdErr.String()}
 		}
 
 		return nil, fmt.Errorf("cmd run: %w", err)

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -35,11 +35,11 @@ func Run(cmd *exec.Cmd) error {
 // StderrError is returned by RunAndLogLines when a command fails and produces
 // output on stderr. Callers can use errors.As to access the raw stderr content.
 type StderrError struct {
-	Stderr string
+	Message string
 }
 
 func (e *StderrError) Error() string {
-	return fmt.Sprintf("stderr: %s", e.Stderr)
+	return e.Message
 }
 
 type Executor struct {
@@ -157,7 +157,7 @@ func (e *Executor) RunAndLogLines(ctx context.Context, logLabels map[string]stri
 	err := e.cmd.Run()
 	if err != nil {
 		if len(stdErr.Bytes()) > 0 {
-			return nil, &StderrError{Stderr: stdErr.String()}
+			return nil, &StderrError{Message: stdErr.String()}
 		}
 
 		return nil, fmt.Errorf("cmd run: %w", err)


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview
Replace fmt.Errorf("stderr: ...") with a custom StderrError type in RunAndLogLines. Callers can use errors.As to detect stderr errors and access raw content without brittle string prefix trimming. Error() returns the same string format — fully backward compatible.
<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

