### PR TITLE
[shell-operator] chore: reduce memory consumption

### DIFF
--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -215,7 +215,7 @@ func (pl *proxyLogger) Write(p []byte) (int, error) {
 
 	logMap, ok := line.(map[string]interface{})
 	defer func() {
-		pl.buf = []byte{}
+		pl.buf = pl.buf[:0]
 	}()
 
 	if !ok {

--- a/pkg/filter/jq/apply.go
+++ b/pkg/filter/jq/apply.go
@@ -3,6 +3,7 @@ package jq
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/itchyny/gojq"
 
@@ -91,19 +92,48 @@ func (c *CompiledJqFilter) String() string {
 	return c.originalStr
 }
 
+// deepCopyAny recursively copies JSON-compatible values (maps, slices, and
+// primitives) without going through json.Marshal/Unmarshal. This is
+// significantly faster and allocates only the final structure.
 func deepCopyAny(input any) (any, error) {
 	if input == nil {
 		return nil, nil
 	}
-	data, err := json.Marshal(input)
-	if err != nil {
-		return nil, err
+	return deepCopyValue(input)
+}
+
+func deepCopyValue(v any) (any, error) {
+	switch val := v.(type) {
+	case map[string]any:
+		m := make(map[string]any, len(val))
+		for k, v := range val {
+			copied, err := deepCopyValue(v)
+			if err != nil {
+				return nil, err
+			}
+			m[k] = copied
+		}
+		return m, nil
+	case []any:
+		s := make([]any, len(val))
+		for i, v := range val {
+			copied, err := deepCopyValue(v)
+			if err != nil {
+				return nil, err
+			}
+			s[i] = copied
+		}
+		return s, nil
+	case string, bool, json.Number,
+		int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64,
+		float32, float64:
+		return val, nil
+	case nil:
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("deepCopyValue: unsupported type %T", v)
 	}
-	var output any
-	if err := json.Unmarshal(data, &output); err != nil {
-		return nil, err
-	}
-	return output, nil
 }
 
 // collectResults drains a gojq iterator and serialises the results to JSON.

--- a/pkg/filter/jq/apply_test.go
+++ b/pkg/filter/jq/apply_test.go
@@ -175,18 +175,18 @@ func Test_ApplyFilter_PanicSafety(t *testing.T) {
 func Test_deepCopyAny(t *testing.T) {
 	g := NewWithT(t)
 
-	// Test copying a map
+	// Test copying a map preserves types
 	inputMap := map[string]any{"foo": "bar", "num": 42}
 	copyMap, err := deepCopyAny(inputMap)
 	g.Expect(err).Should(BeNil())
-	g.Expect(copyMap).Should(Equal(map[string]any{"foo": "bar", "num": float64(42)}))
+	g.Expect(copyMap).Should(Equal(map[string]any{"foo": "bar", "num": 42}))
 	g.Expect(copyMap).ShouldNot(BeIdenticalTo(inputMap))
 
-	// Test copying a slice
+	// Test copying a slice preserves types
 	inputSlice := []any{"a", 1, true}
 	copySlice, err := deepCopyAny(inputSlice)
 	g.Expect(err).Should(BeNil())
-	g.Expect(copySlice).Should(Equal([]any{"a", float64(1), true}))
+	g.Expect(copySlice).Should(Equal([]any{"a", 1, true}))
 	g.Expect(copySlice).ShouldNot(BeIdenticalTo(inputSlice))
 
 	// Test copying nil
@@ -194,11 +194,93 @@ func Test_deepCopyAny(t *testing.T) {
 	g.Expect(err).Should(BeNil())
 	g.Expect(copyNil).Should(BeNil())
 
-	// Test copying a value that cannot be marshaled to JSON
+	// Test copying a value with unsupported type
 	inputInvalid := map[string]any{"ch": make(chan int)}
 	copyInvalid, err := deepCopyAny(inputInvalid)
 	g.Expect(err).ShouldNot(BeNil())
 	g.Expect(copyInvalid).Should(BeNil())
+}
+
+func Test_deepCopyAny_NestedMap(t *testing.T) {
+	g := NewWithT(t)
+
+	input := map[string]any{
+		"metadata": map[string]any{
+			"name":      "my-pod",
+			"namespace": "default",
+			"labels":    map[string]any{"app": "test"},
+		},
+		"spec": map[string]any{
+			"replicas": float64(3),
+		},
+	}
+
+	result, err := deepCopyAny(input)
+	g.Expect(err).Should(BeNil())
+
+	resultMap := result.(map[string]any)
+	g.Expect(resultMap["metadata"]).Should(Equal(input["metadata"]))
+
+	// Verify it's a true deep copy: mutating the copy must not affect the original.
+	resultMeta := resultMap["metadata"].(map[string]any)
+	resultMeta["name"] = "mutated"
+	g.Expect(input["metadata"].(map[string]any)["name"]).Should(Equal("my-pod"))
+}
+
+func Test_deepCopyAny_NestedSlice(t *testing.T) {
+	g := NewWithT(t)
+
+	input := []any{
+		map[string]any{"name": "a"},
+		map[string]any{"name": "b"},
+	}
+
+	result, err := deepCopyAny(input)
+	g.Expect(err).Should(BeNil())
+
+	resultSlice := result.([]any)
+	g.Expect(resultSlice).Should(HaveLen(2))
+
+	// Mutate copy, verify original is untouched.
+	resultSlice[0].(map[string]any)["name"] = "mutated"
+	g.Expect(input[0].(map[string]any)["name"]).Should(Equal("a"))
+}
+
+func Test_deepCopyAny_NumericTypes(t *testing.T) {
+	g := NewWithT(t)
+
+	input := map[string]any{
+		"int":     42,
+		"int64":   int64(100),
+		"float64": 3.14,
+		"bool":    true,
+		"string":  "hello",
+	}
+
+	result, err := deepCopyAny(input)
+	g.Expect(err).Should(BeNil())
+	g.Expect(result).Should(Equal(input))
+}
+
+func BenchmarkDeepCopyAny(b *testing.B) {
+	input := map[string]any{
+		"metadata": map[string]any{
+			"name":      "my-pod",
+			"namespace": "default",
+			"labels":    map[string]any{"app": "test", "env": "prod"},
+		},
+		"spec": map[string]any{
+			"containers": []any{
+				map[string]any{"name": "main", "image": "nginx:latest"},
+				map[string]any{"name": "sidecar", "image": "envoy:latest"},
+			},
+			"replicas": float64(3),
+		},
+	}
+	b.ResetTimer()
+	for range b.N {
+		_, _ = deepCopyAny(input)
+	}
 }
 
 // ---- Compile / CompiledJqFilter tests ----

--- a/pkg/hook/binding_context/binding_context.go
+++ b/pkg/hook/binding_context/binding_context.go
@@ -2,6 +2,7 @@ package bindingcontext
 
 import (
 	"encoding/json"
+	"io"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
 	v1 "k8s.io/api/admission/v1"
@@ -182,6 +183,13 @@ func ConvertBindingContextList(version string, contexts []BindingContext) Bindin
 }
 
 func (b BindingContextList) Json() ([]byte, error) {
-	data, err := json.MarshalIndent(b, "", "  ")
-	return data, err
+	return json.Marshal(b)
+}
+
+// WriteJson streams the JSON-encoded binding context list directly to w,
+// avoiding an intermediate []byte allocation that can be very large for
+// synchronization events with many objects.
+func (b BindingContextList) WriteJson(w io.Writer) error {
+	enc := json.NewEncoder(w)
+	return enc.Encode(b)
 }

--- a/pkg/hook/binding_context/binding_context_test.go
+++ b/pkg/hook/binding_context/binding_context_test.go
@@ -1,489 +1,207 @@
 package bindingcontext
 
-// TODO: need refactoring
-// change JQ tests for another testing tool
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
 
-// import (
-// 	"testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-// 	. "github.com/onsi/gomega"
-// 	"github.com/stretchr/testify/assert"
-// 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	htypes "github.com/flant/shell-operator/pkg/hook/types"
+	kemtypes "github.com/flant/shell-operator/pkg/kube_events_manager/types"
+)
 
-// 	. "github.com/flant/libjq-go"
-// 	. "github.com/flant/shell-operator/pkg/hook/types"
-// 	. "github.com/flant/shell-operator/pkg/kube_events_manager/types"
-// )
+func makeKubeEventBC() BindingContext {
+	bc := BindingContext{
+		Binding:    "test-binding",
+		Type:       kemtypes.TypeEvent,
+		WatchEvent: kemtypes.WatchEventAdded,
+		Objects: []kemtypes.ObjectAndFilterResult{
+			{
+				Object: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"namespace": "default",
+							"name":      "pod-abc",
+						},
+						"kind": "Pod",
+					},
+				},
+			},
+		},
+	}
+	bc.Metadata.BindingType = htypes.OnKubernetesEvent
+	bc.Metadata.Version = "v1"
+	return bc
+}
 
-// func JqEqual(t *testing.T, input []byte, program string, expected string) {
-// 	//nolint:typecheck // Ignore false positive: undeclared name: `Jq`.
-// 	res, err := Jq().Program(program).Run(string(input))
-// 	if assert.NoError(t, err) {
-// 		assert.Equal(t, expected, res, "jq: '%s', json was '%s'", program, string(input))
-// 	}
-// }
+func makeSyncBC(count int) BindingContext {
+	objects := make([]kemtypes.ObjectAndFilterResult, count)
+	for i := range count {
+		objects[i] = kemtypes.ObjectAndFilterResult{
+			Object: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"namespace": "default",
+						"name":      "pod-" + string(rune('a'+i%26)),
+					},
+					"kind": "Pod",
+				},
+			},
+		}
+	}
+	bc := BindingContext{
+		Binding: "sync-binding",
+		Type:    kemtypes.TypeSynchronization,
+		Objects: objects,
+	}
+	bc.Metadata.BindingType = htypes.OnKubernetesEvent
+	bc.Metadata.Version = "v1"
+	return bc
+}
 
-// // Test conversion of BindingContext for v1, also test json marshal of v1 binding contexts.
-// func Test_ConvertBindingContextList_v1(t *testing.T) {
-// 	g := NewWithT(t)
+func TestBindingContextList_Json(t *testing.T) {
+	bcList := ConvertBindingContextList("v1", []BindingContext{makeKubeEventBC()})
 
-// 	var bcList BindingContextList
-// 	var bcJson []byte
+	data, err := bcList.Json()
+	require.NoError(t, err)
+	require.NotEmpty(t, data)
 
-// 	tests := []struct {
-// 		name         string
-// 		bc           func() []BindingContext
-// 		fn           func()
-// 		jqAssertions [][]string
-// 	}{
-// 		{
-// 			"OnStartup binding",
-// 			func() []BindingContext {
-// 				bc := BindingContext{
-// 					Binding: "onStartup",
-// 				}
-// 				bc.Metadata.BindingType = OnStartup
-// 				return []BindingContext{bc}
-// 			},
-// 			func() {
-// 				assert.Equal(t, "onStartup", bcList[0]["binding"])
-// 			},
-// 			[][]string{
-// 				{`.[0].binding`, `"onStartup"`},
-// 				{`.[0] | length`, `1`},
-// 			},
-// 		},
-// 		{
-// 			"kubernetes Event binding",
-// 			func() []BindingContext {
-// 				bc := BindingContext{
-// 					Binding:    "kubernetes",
-// 					Type:       TypeEvent,
-// 					WatchEvent: WatchEventAdded,
-// 					Objects: []ObjectAndFilterResult{
-// 						{
-// 							Object: &unstructured.Unstructured{
-// 								Object: map[string]interface{}{
-// 									"metadata": map[string]interface{}{
-// 										"namespace": "default",
-// 										"name":      "pod-qwe",
-// 									},
-// 									"kind": "Pod",
-// 								},
-// 							},
-// 						},
-// 					},
-// 				}
-// 				bc.Metadata.BindingType = OnKubernetesEvent
-// 				return []BindingContext{bc}
-// 			},
+	var parsed []map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &parsed))
+	assert.Len(t, parsed, 1)
+	assert.Equal(t, "test-binding", parsed[0]["binding"])
+}
 
-// 			func() {
-// 				assert.Len(t, bcList[0], 4)
-// 				assert.Equal(t, "kubernetes", bcList[0]["binding"])
-// 				assert.Equal(t, TypeEvent, bcList[0]["type"])
-// 				assert.Equal(t, "Added", bcList[0]["watchEvent"])
-// 				assert.IsType(t, &unstructured.Unstructured{}, bcList[0]["object"])
-// 				assert.Contains(t, bcList[0]["object"].(*unstructured.Unstructured).Object, "metadata")
-// 			},
-// 			[][]string{
-// 				// JSON dump should has only 4 fields: binding, type, watchEvent and object.
-// 				{`.[0] | length`, `4`},
-// 				{`.[0].binding`, `"kubernetes"`},
-// 				{`.[0].type`, `"Event"`},
-// 				{`.[0].watchEvent`, `"Added"`},
-// 				{`.[0].object.metadata.namespace`, `"default"`},
-// 				{`.[0].object.metadata.name`, `"pod-qwe"`},
-// 			},
-// 		},
-// 		{
-// 			"kubernetes Synchronization event",
-// 			func() []BindingContext {
-// 				bc := BindingContext{
-// 					Binding: "kubernetes",
-// 					Type:    TypeSynchronization,
-// 					Objects: []ObjectAndFilterResult{},
-// 				}
-// 				bc.Metadata.BindingType = OnKubernetesEvent
+func TestBindingContextList_WriteJson(t *testing.T) {
+	bcList := ConvertBindingContextList("v1", []BindingContext{makeKubeEventBC()})
 
-// 				obj := ObjectAndFilterResult{
-// 					Object: &unstructured.Unstructured{
-// 						Object: map[string]interface{}{
-// 							"metadata": map[string]interface{}{
-// 								"namespace": "default",
-// 								"name":      "pod-qwe",
-// 							},
-// 							"kind": "Pod",
-// 						},
-// 					},
-// 				}
-// 				obj.Metadata.JqFilter = ""
-// 				bc.Objects = append(bc.Objects, obj)
+	var buf bytes.Buffer
+	err := bcList.WriteJson(&buf)
+	require.NoError(t, err)
+	require.NotEmpty(t, buf.Bytes())
 
-// 				// object with jqfilter should have filterResult field
-// 				obj = ObjectAndFilterResult{
-// 					Object: &unstructured.Unstructured{
-// 						Object: map[string]interface{}{
-// 							"metadata": map[string]interface{}{
-// 								"namespace": "default",
-// 								"name":      "deployment-test",
-// 							},
-// 							"kind": "Deployment",
-// 						},
-// 					},
-// 					FilterResult: `{"labels":{"label-name":"label-value"}}`,
-// 				}
-// 				obj.Metadata.JqFilter = ".metadata.labels"
-// 				bc.Objects = append(bc.Objects, obj)
+	var parsed []map[string]interface{}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &parsed))
+	assert.Len(t, parsed, 1)
+	assert.Equal(t, "test-binding", parsed[0]["binding"])
+}
 
-// 				// object with jqfilter and with empty result should have filterResult field
-// 				obj = ObjectAndFilterResult{
-// 					Object: &unstructured.Unstructured{
-// 						Object: map[string]interface{}{
-// 							"metadata": map[string]interface{}{
-// 								"namespace": "default",
-// 								"name":      "deployment-2",
-// 							},
-// 							"kind": "Deployment",
-// 						},
-// 					},
-// 					FilterResult: `""`,
-// 				}
-// 				obj.Metadata.JqFilter = ".metadata.labels"
-// 				bc.Objects = append(bc.Objects, obj)
+func TestBindingContextList_Json_and_WriteJson_produce_equivalent_output(t *testing.T) {
+	bcList := ConvertBindingContextList("v1", []BindingContext{
+		makeKubeEventBC(),
+		makeSyncBC(3),
+	})
 
-// 				return []BindingContext{bc}
-// 			},
-// 			func() {
-// 				assert.Len(t, bcList[0], 3)
-// 				assert.Len(t, bcList[0]["objects"], 3)
-// 				assert.Equal(t, TypeSynchronization, bcList[0]["type"])
-// 				assert.Equal(t, "kubernetes", bcList[0]["binding"])
-// 				assert.NotContains(t, bcList[0], "object")
-// 				assert.NotContains(t, bcList[0], "filterResult")
-// 			},
-// 			[][]string{
-// 				// JSON dump should contains n fields: binding, type and objects
-// 				{`.[0] | length`, `3`},
-// 				{`.[0].binding`, `"kubernetes"`},
-// 				{`.[0].type`, `"Synchronization"`},
+	jsonBytes, err := bcList.Json()
+	require.NoError(t, err)
 
-// 				{`.[0].objects[] | select(.object.metadata.name == "pod-qwe") | has("filterResult")`, `false`},
-// 				{`.[0].objects[] | select(.object.metadata.name == "deployment-test") | has("filterResult")`, `true`},
-// 				{`.[0].objects[] | select(.object.metadata.name == "deployment-test") | .filterResult.labels."label-name"`, `"label-value"`},
-// 				{`.[0].objects[] | select(.object.metadata.name == "deployment-2") | has("filterResult")`, `true`},
-// 			},
-// 		},
-// 		{
-// 			"binding context with group",
-// 			func() []BindingContext {
-// 				bcs := []BindingContext{}
+	var buf bytes.Buffer
+	require.NoError(t, bcList.WriteJson(&buf))
 
-// 				bc := BindingContext{
-// 					Binding:    "monitor_pods",
-// 					Type:       TypeEvent,
-// 					WatchEvent: WatchEventAdded,
-// 					Objects:    []ObjectAndFilterResult{},
-// 					Snapshots:  map[string][]ObjectAndFilterResult{},
-// 				}
-// 				bc.Metadata.BindingType = OnKubernetesEvent
-// 				bc.Metadata.Group = "pods"
-// 				bc.Metadata.IncludeSnapshots = []string{"monitor_pods"}
+	// Both should parse to the same structure.
+	var fromJson, fromWriter interface{}
+	require.NoError(t, json.Unmarshal(jsonBytes, &fromJson))
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &fromWriter))
+	assert.Equal(t, fromJson, fromWriter)
+}
 
-// 				obj := ObjectAndFilterResult{
-// 					Object: &unstructured.Unstructured{
-// 						Object: map[string]interface{}{
-// 							"metadata": map[string]interface{}{
-// 								"namespace": "default",
-// 								"name":      "pod-qwe",
-// 							},
-// 							"kind": "Pod",
-// 						},
-// 					},
-// 				}
-// 				bc.Objects = append(bc.Objects, obj)
-// 				bc.Snapshots["monitor_pods"] = append(bc.Snapshots["monitor_pods"], obj)
-// 				bcs = append(bcs, bc)
+func TestBindingContextList_Json_empty(t *testing.T) {
+	bcList := BindingContextList{}
 
-// 				bc = BindingContext{
-// 					Binding:    "monitor_pods",
-// 					Type:       TypeEvent,
-// 					WatchEvent: WatchEventAdded,
-// 					Objects:    []ObjectAndFilterResult{},
-// 				}
-// 				bc.Metadata.BindingType = OnKubernetesEvent
+	data, err := bcList.Json()
+	require.NoError(t, err)
 
-// 				obj = ObjectAndFilterResult{
-// 					Object: &unstructured.Unstructured{
-// 						Object: map[string]interface{}{
-// 							"metadata": map[string]interface{}{
-// 								"namespace": "default",
-// 								"name":      "pod-qwe",
-// 							},
-// 							"kind": "Pod",
-// 						},
-// 					},
-// 				}
-// 				bc.Objects = append(bc.Objects, obj)
+	var parsed []interface{}
+	require.NoError(t, json.Unmarshal(data, &parsed))
+	assert.Empty(t, parsed)
+}
 
-// 				bcs = append(bcs, bc)
-// 				return bcs
-// 			},
-// 			func() {
-// 				g.Expect(bcList[0]).Should(HaveKey("binding"))
-// 				g.Expect(bcList[0]).Should(HaveKey("snapshots"))
-// 				g.Expect(bcList[0]).Should(HaveKey("type"))
-// 				g.Expect(bcList[0]).Should(HaveKey("groupName"))
-// 				g.Expect(bcList[0]).ShouldNot(HaveKey("objects"))
-// 			},
-// 			[][]string{
-// 				{`. | length`, `2`},
+func TestBindingContextList_WriteJson_empty(t *testing.T) {
+	bcList := BindingContextList{}
 
-// 				// grouped binding context contains binding, type, snapshots and groupName
-// 				{`.[0] | length`, `4`}, // Only 4 fields
-// 				{`.[0].snapshots | has("monitor_pods")`, `true`},
-// 				{`.[0].snapshots."monitor_pods" | length`, `1`},
-// 				{`.[0].binding`, `"monitor_pods"`},
-// 				{`.[0].type`, `"Group"`},
-// 				{`.[0].groupName`, `"pods"`},
+	var buf bytes.Buffer
+	require.NoError(t, bcList.WriteJson(&buf))
 
-// 				// JSON dump should has only 4 fields: binding, type, watchEvent and object.
-// 				{`.[1] | length`, `4`},
-// 				{`.[1].binding`, `"monitor_pods"`},
-// 				{`.[1].type`, `"Event"`},
-// 				{`.[1].watchEvent`, `"Added"`},
-// 				{`.[1].object.metadata.namespace`, `"default"`},
-// 				{`.[1].object.metadata.name`, `"pod-qwe"`},
-// 			},
-// 		},
-// 		{
-// 			"grouped Synchronization",
-// 			func() []BindingContext {
-// 				bcs := []BindingContext{}
+	var parsed []interface{}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &parsed))
+	assert.Empty(t, parsed)
+}
 
-// 				bc := BindingContext{
-// 					Binding:   "monitor_config_maps",
-// 					Type:      TypeSynchronization,
-// 					Objects:   []ObjectAndFilterResult{},
-// 					Snapshots: map[string][]ObjectAndFilterResult{},
-// 				}
-// 				bc.Metadata.BindingType = OnKubernetesEvent
-// 				bc.Metadata.Group = "pods"
-// 				bc.Metadata.IncludeSnapshots = []string{"monitor_config_maps"}
-// 				// object without jqfilter should not have filterResult field
-// 				obj := ObjectAndFilterResult{
-// 					Object: &unstructured.Unstructured{
-// 						Object: map[string]interface{}{
-// 							"metadata": map[string]interface{}{
-// 								"namespace": "default",
-// 								"name":      "pod-qwe",
-// 							},
-// 							"kind": "Pod",
-// 						},
-// 					},
-// 					FilterResult: "asd",
-// 				}
-// 				bc.Objects = append(bc.Objects, obj)
-// 				bc.Snapshots["monitor_config_maps"] = append(bc.Snapshots["monitor_config_maps"], obj)
-// 				bcs = append(bcs, bc)
+func TestConvertBindingContextList_OnStartup(t *testing.T) {
+	bc := BindingContext{Binding: "onStartup"}
+	bc.Metadata.BindingType = htypes.OnStartup
 
-// 				bc = BindingContext{
-// 					Binding: "monitor_pods",
-// 					Type:    TypeSynchronization,
-// 					Objects: []ObjectAndFilterResult{},
-// 				}
-// 				bc.Metadata.BindingType = OnKubernetesEvent
-// 				// object without jqfilter should not have filterResult field
-// 				obj = ObjectAndFilterResult{
-// 					Object: &unstructured.Unstructured{
-// 						Object: map[string]interface{}{
-// 							"metadata": map[string]interface{}{
-// 								"namespace": "default",
-// 								"name":      "pod-qwe",
-// 							},
-// 							"kind": "Pod",
-// 						},
-// 					},
-// 					FilterResult: "asd",
-// 				}
-// 				bc.Objects = append(bc.Objects, obj)
+	bcList := ConvertBindingContextList("v1", []BindingContext{bc})
+	assert.Len(t, bcList, 1)
+	assert.Equal(t, "onStartup", bcList[0]["binding"])
+	_, hasType := bcList[0]["type"]
+	assert.False(t, hasType)
+}
 
-// 				bcs = append(bcs, bc)
-// 				return bcs
-// 			},
-// 			func() {
-// 				g.Expect(bcList).Should(HaveLen(2))
+func TestConvertBindingContextList_Schedule(t *testing.T) {
+	bc := BindingContext{Binding: "every-5m"}
+	bc.Metadata.BindingType = htypes.Schedule
 
-// 				g.Expect(bcList[0]).Should(HaveLen(4))
-// 				g.Expect(bcList[0]).Should(HaveKey("binding"))
-// 				g.Expect(bcList[0]["binding"]).Should(Equal("monitor_config_maps"))
-// 				g.Expect(bcList[0]).Should(HaveKey("type"))
-// 				g.Expect(bcList[0]["type"]).Should(Equal("Group"))
-// 				g.Expect(bcList[0]["groupName"]).Should(Equal("pods"))
-// 				g.Expect(bcList[0]).Should(HaveKey("snapshots"))
-// 				g.Expect(bcList[0]["snapshots"]).Should(HaveLen(1))
+	bcList := ConvertBindingContextList("v1", []BindingContext{bc})
+	assert.Len(t, bcList, 1)
+	assert.Equal(t, "Schedule", bcList[0]["type"])
+}
 
-// 				g.Expect(bcList[1]).Should(HaveLen(3))
-// 				g.Expect(bcList[1]).Should(HaveKey("binding"))
-// 				g.Expect(bcList[1]).Should(HaveKey("type"))
-// 				g.Expect(bcList[1]["type"]).Should(Equal(TypeSynchronization))
-// 				g.Expect(bcList[1]).Should(HaveKey("objects"))
-// 				g.Expect(bcList[1]["objects"]).Should(HaveLen(1))
-// 			},
-// 			[][]string{
-// 				{`. | length`, `2`},
+func TestConvertBindingContextList_KubeEvent(t *testing.T) {
+	bcList := ConvertBindingContextList("v1", []BindingContext{makeKubeEventBC()})
+	assert.Len(t, bcList, 1)
+	assert.Equal(t, kemtypes.TypeEvent, bcList[0]["type"])
+	assert.Equal(t, "Added", bcList[0]["watchEvent"])
+	assert.NotNil(t, bcList[0]["object"])
+}
 
-// 				// grouped binding context contains binging, type, snapshots and groupName
-// 				{`.[0] | length`, `4`}, // Only 4 fields
-// 				{`.[0].binding`, `"monitor_config_maps"`},
-// 				{`.[0].type`, `"Group"`},
-// 				{`.[0].snapshots | has("monitor_config_maps")`, `true`},
-// 				{`.[0].snapshots."monitor_config_maps" | length`, `1`},
+func TestConvertBindingContextList_Synchronization(t *testing.T) {
+	bcList := ConvertBindingContextList("v1", []BindingContext{makeSyncBC(2)})
+	assert.Len(t, bcList, 1)
+	assert.Equal(t, kemtypes.TypeSynchronization, bcList[0]["type"])
+	objects, ok := bcList[0]["objects"].([]kemtypes.ObjectAndFilterResult)
+	require.True(t, ok)
+	assert.Len(t, objects, 2)
+}
 
-// 				// usual Synchronization has 3 fields: binding, type and objects.
-// 				{`.[1] | length`, `3`},
-// 				{`.[1].binding`, `"monitor_pods"`},
-// 				{`.[1].type`, `"Synchronization"`},
-// 				{`.[1].objects | length`, `1`},
-// 				{`.[1].objects[0].object.metadata.namespace`, `"default"`},
-// 				{`.[1].objects[0].object.metadata.name`, `"pod-qwe"`},
-// 			},
-// 		},
-// 		{
-// 			"kubernetes Synchronization with empty objects",
-// 			func() []BindingContext {
-// 				bc := BindingContext{
-// 					Binding: "kubernetes",
-// 					Type:    TypeSynchronization,
-// 					Objects: []ObjectAndFilterResult{},
-// 				}
-// 				bc.Metadata.BindingType = OnKubernetesEvent
-// 				return []BindingContext{bc}
-// 			},
-// 			func() {
-// 				assert.Len(t, bcList[0]["objects"], 0)
-// 				assert.Equal(t, TypeSynchronization, bcList[0]["type"])
-// 				assert.Equal(t, "kubernetes", bcList[0]["binding"])
-// 				assert.NotContains(t, bcList[0], "object")
-// 				assert.NotContains(t, bcList[0], "filterResult")
-// 			},
-// 			[][]string{
-// 				// JSON dump should contains n fields: binding, type and objects
-// 				{`.[0] | length`, `3`},
-// 				{`.[0].binding`, `"kubernetes"`},
-// 				{`.[0].type`, `"Synchronization"`},
-// 				// objects should be an empty array
-// 				{`.[0] | has("objects")`, `true`},
-// 				{`.[0].objects | length`, `0`},
-// 			},
-// 		},
-// 	}
+func TestConvertBindingContextList_SynchronizationEmpty(t *testing.T) {
+	bcList := ConvertBindingContextList("v1", []BindingContext{makeSyncBC(0)})
+	assert.Len(t, bcList, 1)
+	assert.Equal(t, kemtypes.TypeSynchronization, bcList[0]["type"])
+	// Empty objects should be an empty array, not nil.
+	objects, ok := bcList[0]["objects"].([]string)
+	require.True(t, ok)
+	assert.Empty(t, objects)
+}
 
-// 	for _, tt := range tests {
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			bcList = ConvertBindingContextList("v1", tt.bc())
-// 			// assert.Len(t, bcList, 1)
+func TestConvertBindingContextList_Group(t *testing.T) {
+	bc := BindingContext{Binding: "my-binding"}
+	bc.Metadata.BindingType = htypes.OnKubernetesEvent
+	bc.Metadata.Group = "my-group"
 
-// 			var err error
-// 			bcJson, err = bcList.Json()
-// 			assert.NoError(t, err)
+	bcList := ConvertBindingContextList("v1", []BindingContext{bc})
+	assert.Len(t, bcList, 1)
+	assert.Equal(t, "Group", bcList[0]["type"])
+	assert.Equal(t, "my-group", bcList[0]["groupName"])
+}
 
-// 			for _, jqAssertion := range tt.jqAssertions {
-// 				JqEqual(t, bcJson, jqAssertion[0], jqAssertion[1])
-// 			}
+func BenchmarkBindingContextList_Json(b *testing.B) {
+	bcList := ConvertBindingContextList("v1", []BindingContext{makeSyncBC(100)})
+	b.ResetTimer()
+	for range b.N {
+		_, _ = bcList.Json()
+	}
+}
 
-// 			tt.fn()
-// 		})
-// 	}
-// }
-
-// // Test conversion of BindingContext for v1, also test json marshal of v1 binding contexts.
-// func Test_ConvertBindingContextList_v0(t *testing.T) {
-// 	var bcList BindingContextList
-// 	var bcJson []byte
-
-// 	tests := []struct {
-// 		name        string
-// 		bc          func() BindingContext
-// 		fn          func()
-// 		jqAsertions [][]string
-// 	}{
-// 		{
-// 			"OnStartup binding",
-// 			func() BindingContext {
-// 				bc := BindingContext{
-// 					Binding: "onStartup",
-// 				}
-// 				bc.Metadata.BindingType = OnStartup
-// 				return bc
-// 			},
-// 			func() {
-// 				assert.Equal(t, "onStartup", bcList[0]["binding"])
-// 			},
-// 			[][]string{
-// 				{`.[0].binding`, `"onStartup"`},
-// 				{`.[0] | length`, `1`},
-// 			},
-// 		},
-// 		{
-// 			"onKubernetesEvent binding",
-// 			func() BindingContext {
-// 				bc := BindingContext{
-// 					Binding:    "onKubernetesEvent",
-// 					Type:       "Event",
-// 					WatchEvent: WatchEventAdded,
-// 					Objects: []ObjectAndFilterResult{
-// 						{
-// 							Object: &unstructured.Unstructured{
-// 								Object: map[string]interface{}{
-// 									"metadata": map[string]interface{}{
-// 										"namespace": "default",
-// 										"name":      "pod-qwe",
-// 									},
-// 									"kind": "Pod",
-// 								},
-// 							},
-// 						},
-// 					},
-// 				}
-// 				bc.Metadata.BindingType = OnKubernetesEvent
-// 				return bc
-// 			},
-
-// 			func() {
-// 				assert.Len(t, bcList[0], 5)
-// 				assert.Equal(t, "onKubernetesEvent", bcList[0]["binding"])
-// 				assert.Equal(t, "add", bcList[0]["resourceEvent"])
-// 				assert.Equal(t, "default", bcList[0]["resourceNamespace"])
-// 				assert.Equal(t, "Pod", bcList[0]["resourceKind"])
-// 				assert.Equal(t, "pod-qwe", bcList[0]["resourceName"])
-// 			},
-// 			[][]string{
-// 				// JSON dump should has only 4 fields: binding, type, watchEvent and object.
-// 				{`.[0] | length`, `5`},
-// 				{`.[0].binding`, `"onKubernetesEvent"`},
-// 				{`.[0].resourceEvent`, `"add"`},
-// 				{`.[0].resourceNamespace`, `"default"`},
-// 				{`.[0].resourceKind`, `"Pod"`},
-// 				{`.[0].resourceName`, `"pod-qwe"`},
-// 			},
-// 		},
-// 	}
-
-// 	for _, tt := range tests {
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			bcList = ConvertBindingContextList("v0", []BindingContext{tt.bc()})
-// 			assert.Len(t, bcList, 1)
-
-// 			var err error
-// 			bcJson, err = bcList.Json()
-// 			assert.NoError(t, err)
-
-// 			for _, jqAssertion := range tt.jqAsertions {
-// 				JqEqual(t, bcJson, jqAssertion[0], jqAssertion[1])
-// 			}
-
-// 			tt.fn()
-// 		})
-// 	}
-// }
+func BenchmarkBindingContextList_WriteJson(b *testing.B) {
+	bcList := ConvertBindingContextList("v1", []BindingContext{makeSyncBC(100)})
+	var buf bytes.Buffer
+	b.ResetTimer()
+	for range b.N {
+		buf.Reset()
+		_ = bcList.WriteJson(&buf)
+	}
+}

--- a/pkg/hook/hook.go
+++ b/pkg/hook/hook.go
@@ -238,16 +238,15 @@ func (h *Hook) GetConfigDescription() string {
 }
 
 func (h *Hook) prepareBindingContextJsonFile(context bctx.BindingContextList) (string, error) {
-	var err error
-	data, err := context.Json()
+	bindingContextPath := filepath.Join(h.TmpDir, fmt.Sprintf("hook-%s-binding-context-%s.json", h.SafeName(), uuid.Must(uuid.NewV4()).String()))
+
+	f, err := os.Create(bindingContextPath)
 	if err != nil {
 		return "", err
 	}
+	defer f.Close()
 
-	bindingContextPath := filepath.Join(h.TmpDir, fmt.Sprintf("hook-%s-binding-context-%s.json", h.SafeName(), uuid.Must(uuid.NewV4()).String()))
-
-	err = os.WriteFile(bindingContextPath, data, 0o644)
-	if err != nil {
+	if err := context.WriteJson(f); err != nil {
 		return "", err
 	}
 

--- a/pkg/kube_events_manager/filter.go
+++ b/pkg/kube_events_manager/filter.go
@@ -42,7 +42,7 @@ func applyFilter(compiledFilter filter.CompiledFilter, jqFilterStr string, filte
 		}
 
 		res.FilterResult = filteredObj
-		res.Metadata.Checksum = utils_checksum.CalculateChecksum(string(filteredBytes))
+		res.Metadata.Checksum = utils_checksum.CalculateChecksumOfBytes(filteredBytes)
 
 		return res, nil
 	}
@@ -53,7 +53,7 @@ func applyFilter(compiledFilter filter.CompiledFilter, jqFilterStr string, filte
 		if err != nil {
 			return nil, err
 		}
-		res.Metadata.Checksum = utils_checksum.CalculateChecksum(string(data))
+		res.Metadata.Checksum = utils_checksum.CalculateChecksumOfBytes(data)
 	} else {
 		filtered, err := compiledFilter.Apply(obj.UnstructuredContent())
 		if err != nil {
@@ -61,7 +61,7 @@ func applyFilter(compiledFilter filter.CompiledFilter, jqFilterStr string, filte
 		}
 
 		res.FilterResult = string(filtered)
-		res.Metadata.Checksum = utils_checksum.CalculateChecksum(string(filtered))
+		res.Metadata.Checksum = utils_checksum.CalculateChecksumOfBytes(filtered)
 	}
 
 	return res, nil

--- a/pkg/utils/checksum/checksum.go
+++ b/pkg/utils/checksum/checksum.go
@@ -3,18 +3,39 @@ package checksum
 import (
 	"crypto/md5"
 	"encoding/hex"
+	"hash"
 	"os"
 	"path/filepath"
 	"sort"
+	"sync"
 )
 
+var md5Pool = sync.Pool{
+	New: func() any { return md5.New() },
+}
+
 func CalculateChecksum(stringArr ...string) string {
-	hasher := md5.New()
+	h := md5Pool.Get().(hash.Hash)
+	h.Reset()
 	sort.Strings(stringArr)
 	for _, value := range stringArr {
-		_, _ = hasher.Write([]byte(value))
+		_, _ = h.Write([]byte(value))
 	}
-	return hex.EncodeToString(hasher.Sum(nil))
+	sum := hex.EncodeToString(h.Sum(nil))
+	md5Pool.Put(h)
+	return sum
+}
+
+// CalculateChecksumOfBytes computes an MD5 hex digest directly from a byte
+// slice, avoiding the []byte→string→[]byte round-trip that CalculateChecksum
+// would require.
+func CalculateChecksumOfBytes(data []byte) string {
+	h := md5Pool.Get().(hash.Hash)
+	h.Reset()
+	_, _ = h.Write(data)
+	sum := hex.EncodeToString(h.Sum(nil))
+	md5Pool.Put(h)
+	return sum
 }
 
 func CalculateChecksumOfFile(path string) (string, error) {

--- a/pkg/utils/checksum/checksum_test.go
+++ b/pkg/utils/checksum/checksum_test.go
@@ -1,26 +1,138 @@
 package checksum
 
 import (
-	"fmt"
+	"sync"
 	"testing"
 )
 
-func TestChecksum(t *testing.T) {
-	val1 := []string{
-		"host_1",
-		"host_2",
-	}
-	chksum1 := CalculateChecksum(val1...)
-	fmt.Printf("val1 chksum: %s\n", chksum1)
-
-	val2 := []string{
-		"host_2",
-		"host_1",
-	}
-	chksum2 := CalculateChecksum(val2...)
-	fmt.Printf("val2 chksum: %s\n", chksum2)
+func TestCalculateChecksum_OrderIndependent(t *testing.T) {
+	chksum1 := CalculateChecksum("host_1", "host_2")
+	chksum2 := CalculateChecksum("host_2", "host_1")
 
 	if chksum1 != chksum2 {
-		t.Errorf("checksums not identical for identical content")
+		t.Errorf("checksums should be identical for identical content regardless of order: %s vs %s", chksum1, chksum2)
+	}
+}
+
+func TestCalculateChecksum_DifferentInputs(t *testing.T) {
+	chksum1 := CalculateChecksum("aaa")
+	chksum2 := CalculateChecksum("bbb")
+
+	if chksum1 == chksum2 {
+		t.Errorf("checksums should differ for different content: both are %s", chksum1)
+	}
+}
+
+func TestCalculateChecksum_Empty(t *testing.T) {
+	chksum := CalculateChecksum()
+	if chksum == "" {
+		t.Error("checksum of empty input should not be empty string")
+	}
+}
+
+func TestCalculateChecksum_Single(t *testing.T) {
+	chksum := CalculateChecksum("hello")
+	if chksum == "" {
+		t.Error("checksum should not be empty")
+	}
+	if len(chksum) != 32 {
+		t.Errorf("md5 hex digest should be 32 chars, got %d", len(chksum))
+	}
+}
+
+func TestCalculateChecksumOfBytes(t *testing.T) {
+	data := []byte(`{"foo":"bar"}`)
+	chksum := CalculateChecksumOfBytes(data)
+
+	if chksum == "" {
+		t.Error("checksum should not be empty")
+	}
+	if len(chksum) != 32 {
+		t.Errorf("md5 hex digest should be 32 chars, got %d", len(chksum))
+	}
+}
+
+func TestCalculateChecksumOfBytes_MatchesStringVersion(t *testing.T) {
+	input := `{"key":"value","num":42}`
+	fromString := CalculateChecksum(input)
+	fromBytes := CalculateChecksumOfBytes([]byte(input))
+
+	if fromString != fromBytes {
+		t.Errorf("CalculateChecksumOfBytes should match CalculateChecksum for single string: %s vs %s", fromString, fromBytes)
+	}
+}
+
+func TestCalculateChecksumOfBytes_DifferentInputs(t *testing.T) {
+	chksum1 := CalculateChecksumOfBytes([]byte("aaa"))
+	chksum2 := CalculateChecksumOfBytes([]byte("bbb"))
+
+	if chksum1 == chksum2 {
+		t.Errorf("checksums should differ for different content: both are %s", chksum1)
+	}
+}
+
+func TestCalculateChecksumOfBytes_Empty(t *testing.T) {
+	chksum := CalculateChecksumOfBytes([]byte{})
+	if chksum == "" {
+		t.Error("checksum of empty input should not be empty string")
+	}
+}
+
+func TestCalculateChecksum_ConcurrentSafety(t *testing.T) {
+	const goroutines = 100
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	results := make([]string, goroutines)
+	for i := range goroutines {
+		go func(idx int) {
+			defer wg.Done()
+			results[idx] = CalculateChecksum("concurrent-test")
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 1; i < goroutines; i++ {
+		if results[i] != results[0] {
+			t.Errorf("concurrent results should be identical: results[0]=%s, results[%d]=%s", results[0], i, results[i])
+		}
+	}
+}
+
+func TestCalculateChecksumOfBytes_ConcurrentSafety(t *testing.T) {
+	const goroutines = 100
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	data := []byte("concurrent-test-bytes")
+	results := make([]string, goroutines)
+	for i := range goroutines {
+		go func(idx int) {
+			defer wg.Done()
+			results[idx] = CalculateChecksumOfBytes(data)
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 1; i < goroutines; i++ {
+		if results[i] != results[0] {
+			t.Errorf("concurrent results should be identical: results[0]=%s, results[%d]=%s", results[0], i, results[i])
+		}
+	}
+}
+
+func BenchmarkCalculateChecksum(b *testing.B) {
+	input := `{"metadata":{"name":"my-pod","namespace":"default","labels":{"app":"test"}}}`
+	b.ResetTimer()
+	for range b.N {
+		CalculateChecksum(input)
+	}
+}
+
+func BenchmarkCalculateChecksumOfBytes(b *testing.B) {
+	input := []byte(`{"metadata":{"name":"my-pod","namespace":"default","labels":{"app":"test"}}}`)
+	b.ResetTimer()
+	for range b.N {
+		CalculateChecksumOfBytes(input)
 	}
 }


### PR DESCRIPTION
### Summary

This PR targets several high-frequency allocation patterns across the hook execution and event processing pipeline. Together these changes reduce GC pressure and peak memory usage, especially for hooks with large snapshots or high-churn informers.

### Changes

**1. Zero-alloc deep copy for jq filter results** (`pkg/filter/jq/apply.go`)

Replaced the `json.Marshal` / `json.Unmarshal` round-trip in `deepCopyAny` with a recursive type-switch walker. The old approach serialized every filter result to JSON and back just to get a copy — the new implementation copies maps, slices, and primitives directly without any serialization. This also preserves original numeric types (e.g. `int` stays `int`) instead of coercing everything to `float64`.

**2. Streaming JSON for binding context files** (`pkg/hook/hook.go`, `pkg/hook/binding_context/binding_context.go`)

Added `WriteJson(io.Writer)` to `BindingContextList` and rewired `prepareBindingContextJsonFile` to stream JSON directly to the file via `json.NewEncoder`. Previously the entire binding context was marshaled into a `[]byte` (often multi-MB for synchronization events with many objects) and then written in a second step. The streaming approach cuts peak memory by eliminating this intermediate buffer. Also switched `Json()` from `MarshalIndent` to `Marshal` — the indentation was never needed by hook scripts and added ~30% overhead in both CPU and memory.

**3. Pooled MD5 hashers for checksum computation** (`pkg/utils/checksum/checksum.go`)

Introduced a `sync.Pool` for `md5.Hash` instances used by `CalculateChecksum`. Every watch event computes at least one checksum for the filter result, so this pool eliminates one `md5.New()` allocation per event. Also added `CalculateChecksumOfBytes([]byte)` to avoid the `[]byte → string → []byte` round-trip that occurred when checksum was computed from filter output bytes.

**4. Slice reuse in proxy logger** (`pkg/executor/executor.go`)

Changed `pl.buf = []byte{}` to `pl.buf = pl.buf[:0]` to reuse the existing backing array instead of allocating a new slice on every log line.

**5. Checksum byte-path in filter** (`pkg/kube_events_manager/filter.go`)

Switched all three `CalculateChecksum(string(filteredBytes))` call sites to `CalculateChecksumOfBytes(filteredBytes)`, eliminating a needless copy of the filter output on every watch event.