### PR TITLE
fix(metric): substitute {PREFIX} in kube-client MetricsAdapter

### DIFF
--- a/pkg/metric/adapter.go
+++ b/pkg/metric/adapter.go
@@ -6,6 +6,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	klient "github.com/flant/kube-client/client"
+	"github.com/flant/shell-operator/pkg/metrics"
 	utils "github.com/flant/shell-operator/pkg/utils/labels"
 )
 
@@ -18,17 +19,22 @@ var _ klient.MetricStorage = (*MetricsAdapter)(nil)
 type MetricsAdapter struct {
 	Storage metricsstorage.Storage
 	Logger  *log.Logger
+	prefix  string
 }
 
-func NewMetricsAdapter(storage metricsstorage.Storage, logger *log.Logger) *MetricsAdapter {
-	return &MetricsAdapter{Storage: storage, Logger: logger}
+func NewMetricsAdapter(storage metricsstorage.Storage, prefix string, logger *log.Logger) *MetricsAdapter {
+	return &MetricsAdapter{Storage: storage, prefix: prefix, Logger: logger}
+}
+
+func (a *MetricsAdapter) metricName(name string) string {
+	return metrics.ReplacePrefix(name, a.prefix)
 }
 
 // RegisterCounter registers a counter using the external storage
 func (a *MetricsAdapter) RegisterCounter(metric string, labels map[string]string) *prometheus.CounterVec {
 	// Use external storage to register the counter
 	labelNames := utils.LabelNames(labels)
-	_, err := a.Storage.RegisterCounter(metric, labelNames)
+	_, err := a.Storage.RegisterCounter(a.metricName(metric), labelNames)
 	if err != nil {
 		a.Logger.Warn("failed to register counter metric", log.Err(err))
 	}
@@ -39,14 +45,14 @@ func (a *MetricsAdapter) RegisterCounter(metric string, labels map[string]string
 // CounterAdd adds a value to a counter using the external storage
 func (a *MetricsAdapter) CounterAdd(metric string, value float64, labels map[string]string) {
 	// Use external storage for the actual counter operation
-	a.Storage.CounterAdd(metric, value, labels)
+	a.Storage.CounterAdd(a.metricName(metric), value, labels)
 }
 
 // RegisterHistogram registers a histogram using the external storage
 func (a *MetricsAdapter) RegisterHistogram(metric string, labels map[string]string, buckets []float64) *prometheus.HistogramVec {
 	// Use external storage to register the histogram
 	labelNames := utils.LabelNames(labels)
-	_, err := a.Storage.RegisterHistogram(metric, labelNames, buckets)
+	_, err := a.Storage.RegisterHistogram(a.metricName(metric), labelNames, buckets)
 	if err != nil {
 		a.Logger.Warn("failed to register histogram metric", log.Err(err))
 	}
@@ -57,5 +63,5 @@ func (a *MetricsAdapter) RegisterHistogram(metric string, labels map[string]stri
 // HistogramObserve observes a value in a histogram using the external storage
 func (a *MetricsAdapter) HistogramObserve(metric string, value float64, labels map[string]string, buckets []float64) {
 	// Use external storage for the actual histogram operation
-	a.Storage.HistogramObserve(metric, value, labels, buckets)
+	a.Storage.HistogramObserve(a.metricName(metric), value, labels, buckets)
 }

--- a/pkg/metric/adapter_test.go
+++ b/pkg/metric/adapter_test.go
@@ -1,0 +1,71 @@
+package metric_test
+
+import (
+	"testing"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
+	metricsstorage "github.com/deckhouse/deckhouse/pkg/metrics-storage"
+	dto "github.com/prometheus/client_model/go"
+	. "github.com/onsi/gomega"
+
+	"github.com/flant/shell-operator/pkg/metric"
+)
+
+func TestMetricsAdapter_ReplacesPrefixInMetricNames(t *testing.T) {
+	g := NewWithT(t)
+
+	const prefix = "shell_operator_"
+	ms := metricsstorage.NewMetricStorage(metricsstorage.WithNewRegistry())
+	adapter := metric.NewMetricsAdapter(ms, prefix, log.NewNop())
+
+	metricName := "{PREFIX}kubernetes_client_rate_limiter_latency_seconds"
+	adapter.RegisterHistogram(metricName, map[string]string{"verb": "GET"}, []float64{0.005, 0.01})
+	adapter.HistogramObserve(metricName, 0.001, map[string]string{"verb": "GET"}, []float64{0.005, 0.01})
+
+	expectedName := prefix + "kubernetes_client_rate_limiter_latency_seconds"
+	families, err := ms.Gather()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var found bool
+	for _, family := range families {
+		if family.GetName() == expectedName {
+			found = true
+			break
+		}
+	}
+	g.Expect(found).To(BeTrue(), "expected metric %q in gather output, got %v", expectedName, metricFamilyNames(families))
+}
+
+func TestMetricsAdapter_ReplacesPrefixForCounter(t *testing.T) {
+	g := NewWithT(t)
+
+	const prefix = "test_"
+	ms := metricsstorage.NewMetricStorage(metricsstorage.WithNewRegistry())
+	adapter := metric.NewMetricsAdapter(ms, prefix, log.NewNop())
+
+	metricName := "{PREFIX}example_total"
+	adapter.RegisterCounter(metricName, nil)
+	adapter.CounterAdd(metricName, 1, nil)
+
+	expectedName := prefix + "example_total"
+	families, err := ms.Gather()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var found bool
+	for _, family := range families {
+		if family.GetName() == expectedName {
+			found = true
+			g.Expect(family.GetMetric()[0].GetCounter().GetValue()).To(Equal(float64(1)))
+			break
+		}
+	}
+	g.Expect(found).To(BeTrue())
+}
+
+func metricFamilyNames(families []*dto.MetricFamily) []string {
+	names := make([]string, 0, len(families))
+	for _, f := range families {
+		names = append(names, f.GetName())
+	}
+	return names
+}

--- a/pkg/shell-operator/kube_client.go
+++ b/pkg/shell-operator/kube_client.go
@@ -37,7 +37,7 @@ func defaultMainKubeClient(cfg KubeClientConfig, metricStorage metricsstorage.St
 	client.WithContextName(cfg.Context)
 	client.WithConfigPath(cfg.Config)
 	client.WithRateLimiterSettings(cfg.QPS, cfg.Burst)
-	client.WithMetricStorage(metric.NewMetricsAdapter(metricStorage, logger.Named("kube-client-metrics-adapter")))
+	client.WithMetricStorage(metric.NewMetricsAdapter(metricStorage, app.PrometheusMetricsPrefix, logger.Named("kube-client-metrics-adapter")))
 	client.WithMetricLabels(utils.DefaultIfEmpty(metricLabels, defaultMainKubeClientMetricLabels))
 	return client
 }
@@ -50,7 +50,7 @@ func initDefaultMainKubeClient(metricStorage metricsstorage.Storage, logger *log
 		Burst:   app.KubeClientBurst,
 	}
 	//nolint:staticcheck
-	klient.RegisterKubernetesClientMetrics(metric.NewMetricsAdapter(metricStorage, logger.Named("kube-client-metrics-adapter")), defaultMainKubeClientMetricLabels)
+	klient.RegisterKubernetesClientMetrics(metric.NewMetricsAdapter(metricStorage, app.PrometheusMetricsPrefix, logger.Named("kube-client-metrics-adapter")), defaultMainKubeClientMetricLabels)
 	kubeClient := defaultMainKubeClient(cfg, metricStorage, defaultMainKubeClientMetricLabels, logger.Named("main-kube-client"))
 	err := kubeClient.Init()
 	if err != nil {
@@ -65,7 +65,7 @@ func defaultObjectPatcherKubeClient(cfg KubeClientConfig, metricStorage metricss
 	client.WithContextName(cfg.Context)
 	client.WithConfigPath(cfg.Config)
 	client.WithRateLimiterSettings(cfg.QPS, cfg.Burst)
-	client.WithMetricStorage(metric.NewMetricsAdapter(metricStorage, logger.Named("kube-client-metrics-adapter")))
+	client.WithMetricStorage(metric.NewMetricsAdapter(metricStorage, app.PrometheusMetricsPrefix, logger.Named("kube-client-metrics-adapter")))
 	client.WithMetricLabels(utils.DefaultIfEmpty(metricLabels, defaultObjectPatcherKubeClientMetricLabels))
 	if cfg.Timeout > 0 {
 		client.WithTimeout(cfg.Timeout)


### PR DESCRIPTION
## What

Fixes #865

kube-client passes metric names containing a `{PREFIX}` placeholder through `MetricsAdapter`. The adapter forwarded those names unchanged, so Prometheus exposed series like `_PREFIX_kubernetes_client_rate_limiter_latency_seconds` on `/metrics`.

## Changes

- `MetricsAdapter` now takes the configured Prometheus metrics prefix and applies `metrics.ReplacePrefix` before register/add/observe calls
- Wire `app.PrometheusMetricsPrefix` from `kube_client.go`
- Unit tests in `pkg/metric/adapter_test.go`

## Verification

`go test ./pkg/metric/... -count=1`