### PR TITLE
fix(hook): keep counter add metrics ungrouped by default

### DIFF
--- a/pkg/hook/operation.go
+++ b/pkg/hook/operation.go
@@ -80,7 +80,10 @@ func MetricOperationsFromReader(r io.Reader, defaultGroup string) ([]MetricOpera
 			metricOperation.Value = metricOperation.Add
 		}
 
-		if metricOperation.Group == "" {
+		if metricOperation.Group == "" && metricOperation.Action != "add" {
+			// Counter "add" operations without an explicit group must stay ungrouped so
+			// values accumulate across hook runs. Gauges and histograms still get the
+			// hook name as the default group for expire-and-refresh semantics.
 			metricOperation.Group = defaultGroup
 		}
 

--- a/pkg/hook/operation_group_test.go
+++ b/pkg/hook/operation_group_test.go
@@ -1,0 +1,107 @@
+package hook
+
+import (
+	"testing"
+
+	metricsstorage "github.com/deckhouse/deckhouse/pkg/metrics-storage"
+	"github.com/deckhouse/deckhouse/pkg/metrics-storage/operation"
+	. "github.com/onsi/gomega"
+)
+
+func TestMetricOperationsFromBytes_CounterAddWithoutDefaultGroup(t *testing.T) {
+	g := NewWithT(t)
+
+	ops, err := MetricOperationsFromBytes([]byte(`{"name":"my_counter","action":"add","value":1}`), "my-hook")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ops).To(HaveLen(1))
+	g.Expect(ops[0].Group).To(BeEmpty())
+}
+
+func TestMetricOperationsFromBytes_GaugeSetGetsDefaultGroup(t *testing.T) {
+	g := NewWithT(t)
+
+	ops, err := MetricOperationsFromBytes([]byte(`{"name":"my_gauge","action":"set","value":1}`), "my-hook")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ops).To(HaveLen(1))
+	g.Expect(ops[0].Group).To(Equal("my-hook"))
+}
+
+func TestMetricOperationsFromBytes_ExplicitGroupPreservedForCounter(t *testing.T) {
+	g := NewWithT(t)
+
+	ops, err := MetricOperationsFromBytes([]byte(`{"name":"my_counter","action":"add","value":1,"group":"custom"}`), "my-hook")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ops[0].Group).To(Equal("custom"))
+}
+
+func TestCounterAddAccumulatesAcrossGroupedBatches(t *testing.T) {
+	g := NewWithT(t)
+
+	ms := metricsstorage.NewMetricStorage(metricsstorage.WithNewRegistry())
+
+	remap := func(ops []MetricOperation) []operation.MetricOperation {
+		result := make([]operation.MetricOperation, 0, len(ops))
+		for _, op := range ops {
+			val := *op.Value
+			result = append(result, operation.MetricOperation{
+				Name:   op.Name,
+				Value:  &val,
+				Group:  op.Group,
+				Action: operation.ActionCounterAdd,
+			})
+		}
+		return result
+	}
+
+	for i := 0; i < 3; i++ {
+		parsed, err := MetricOperationsFromBytes([]byte(`{"name":"runs_total","action":"add","value":1}`), "cron-hook")
+		g.Expect(err).NotTo(HaveOccurred())
+		err = ms.ApplyBatchOperations(remap(parsed), nil)
+		g.Expect(err).NotTo(HaveOccurred())
+	}
+
+	families, err := ms.Gather()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var value float64
+	for _, family := range families {
+		if family.GetName() == "runs_total" {
+			value = family.GetMetric()[0].GetCounter().GetValue()
+			break
+		}
+	}
+	g.Expect(value).To(Equal(float64(3)))
+}
+
+func TestCounterAddWithExplicitGroupStillExpires(t *testing.T) {
+	g := NewWithT(t)
+
+	ms := metricsstorage.NewMetricStorage(metricsstorage.WithNewRegistry())
+
+	op := operation.MetricOperation{
+		Name:   "grouped_counter",
+		Group:  "my-group",
+		Action: operation.ActionCounterAdd,
+	}
+	val := 5.0
+	op.Value = &val
+
+	err := ms.ApplyBatchOperations([]operation.MetricOperation{op}, nil)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	err = ms.ApplyBatchOperations([]operation.MetricOperation{op}, nil)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	families, err := ms.Gather()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var value float64
+	for _, family := range families {
+		if family.GetName() == "grouped_counter" {
+			value = family.GetMetric()[0].GetCounter().GetValue()
+			break
+		}
+	}
+	// Grouped path expires before apply, so the counter is reset each batch.
+	g.Expect(value).To(Equal(float64(5)))
+}


### PR DESCRIPTION
## What

Fixes #868

When a hook emits a counter with `action: add` and no explicit `group`, the parser assigned the hook name as the default group. Grouped metric batches expire all series in the group before applying new values, so counters were reset on every run.

## Changes

- Do not assign `defaultGroup` for `action: add` when `group` is omitted
- Gauges and histograms still get the hook name as the default group for expire-and-refresh semantics
- Tests cover parsing behavior and cumulative counter updates via `ApplyBatchOperations`

## Verification

`go test ./pkg/hook/ -run 'TestMetricOperations|TestCounterAdd' -count=1`