### PR TITLE
[shell-operator] replace deprecated rbac examples

### DIFF
--- a/docs/src/HOOKS.md
+++ b/docs/src/HOOKS.md
@@ -218,7 +218,7 @@ kubernetes:
 
 - `name` is an optional identifier. It is used to distinguish different bindings during runtime. See also [binding context](#binding-context).
 
-- `apiVersion` is an optional group and version of object API. For example, it is `v1` for core objects (Pod, etc.), `rbac.authorization.k8s.io/v1beta1` for ClusterRole and `monitoring.coreos.com/v1` for prometheus-operator.
+- `apiVersion` is an optional group and version of object API. For example, it is `v1` for core objects (Pod, etc.), `rbac.authorization.k8s.io/v1` for ClusterRole and `monitoring.coreos.com/v1` for prometheus-operator.
 
 - `kind` is the type of a monitored Kubernetes resource. This field is required. CRDs are supported, but the resource should be registered in the cluster before Shell-operator starts. This can be checked with `kubectl api-resources` command. You can specify a case-insensitive name, kind or short name in this field. For example, to monitor a DaemonSet these forms are valid:
 

--- a/examples/101-monitor-pods/shell-operator-rbac.yaml
+++ b/examples/101-monitor-pods/shell-operator-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   name: monitor-pods-acc
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: monitor-pods
@@ -15,7 +15,7 @@ rules:
   verbs: ["get", "watch", "list"]
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: monitor-pods

--- a/examples/102-monitor-namespaces/shell-operator-rbac.yaml
+++ b/examples/102-monitor-namespaces/shell-operator-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   name: monitor-namespaces-acc
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: monitor-namespaces
@@ -15,7 +15,7 @@ rules:
   verbs: ["get", "watch", "list"]
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: monitor-namespaces

--- a/examples/104-secret-copier/shell-operator-rbac.yaml
+++ b/examples/104-secret-copier/shell-operator-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   name: secret-copier-acc
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: secret-copier
@@ -18,7 +18,7 @@ rules:
   verbs: ["*"]
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: secret-copier

--- a/examples/106-monitor-events/shell-operator-rbac.yaml
+++ b/examples/106-monitor-events/shell-operator-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   name: monitor-events-acc
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: monitor-events
@@ -15,7 +15,7 @@ rules:
   verbs: ["get", "watch", "list"]
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: monitor-events

--- a/examples/200-advanced/shell-operator-rbac.yaml
+++ b/examples/200-advanced/shell-operator-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   name: advanced-acc
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: monitor-namespaces
@@ -15,7 +15,7 @@ rules:
   verbs: ["get", "watch", "list"]
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: monitor-namespaces

--- a/examples/201-install-with-helm-chart/templates/shell-operator-rbac.yaml
+++ b/examples/201-install-with-helm-chart/templates/shell-operator-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   name: example-helm-acc
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: example-helm
@@ -15,7 +15,7 @@ rules:
   verbs: ["get", "watch", "list"]
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: example-helm

--- a/examples/204-validating-webhook/templates/rbac.yaml
+++ b/examples/204-validating-webhook/templates/rbac.yaml
@@ -7,7 +7,7 @@ metadata:
     heritage: example-204
 ---
 # Create and update ValidatingWebhookConfiguration
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: example-204
@@ -19,7 +19,7 @@ rules:
   verbs: ["create", "list", "update"]
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: example-204

--- a/examples/210-conversion-webhook/templates/rbac.yaml
+++ b/examples/210-conversion-webhook/templates/rbac.yaml
@@ -7,7 +7,7 @@ metadata:
     heritage: example-210
 ---
 # Create and update ValidatingWebhookConfiguration
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: example-210
@@ -22,7 +22,7 @@ rules:
   verbs: ["get", "list", "watch"]
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: example-210

--- a/examples/220-execution-rate/templates/rbac.yaml
+++ b/examples/220-execution-rate/templates/rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     heritage: example-220
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: example-220
@@ -17,7 +17,7 @@ rules:
   resources: ["crontabs"]
   verbs: ["get", "list", "watch"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: example-220


### PR DESCRIPTION
The rbac.authorization.k8s.io/v1beta1 API was deprecated in Kubernetes 1.17 and removed in 1.22. Update all example ClusterRole and ClusterRoleBinding manifests (plus the HOOKS.md reference) to use the stable rbac.authorization.k8s.io/v1 API so the examples apply cleanly on current Kubernetes versions.

Fixes #709

<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

<!-- Describe your changes briefly here. -->

#### What this PR does / why we need it

<!--
- Please state in detail why we need this PR and what it solves.
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->

#### Special notes for your reviewer
