### PR TITLE
[shell-operator] fix: retry webhook manager initialization and submit calls

### DIFF
--- a/pkg/kube_events_manager/kube_events_manager.go
+++ b/pkg/kube_events_manager/kube_events_manager.go
@@ -93,6 +93,15 @@ func (mgr *kubeEventsManager) WithMetricStorage(mstor metricsstorage.Storage) {
 // TODO use Context to stop informers
 func (mgr *kubeEventsManager) AddMonitor(monitorConfig *MonitorConfig) error {
 	mgr.logger.Debug("add kubernetes monitor", slog.String(pkg.LogKeyConfig, fmt.Sprintf("%+v", monitorConfig)))
+
+	// Ensure MonitorConfig.Logger is set: resource_informer and
+	// namespace_informer access this field directly for error-path
+	// logging.  Propagate here (rather than inside NewMonitor) so that
+	// NewMonitor does not silently mutate a caller-owned struct.
+	if monitorConfig.Logger == nil {
+		monitorConfig.Logger = mgr.logger.Named("monitor")
+	}
+
 	mon := NewMonitor(
 		mgr.ctx,
 		mgr.KubeClient,

--- a/pkg/kube_events_manager/monitor.go
+++ b/pkg/kube_events_manager/monitor.go
@@ -137,6 +137,13 @@ var _ Monitor = (*monitor)(nil)
 func NewMonitor(ctx context.Context, client *klient.Client, mstor metricsstorage.Storage, factoryStore *FactoryStore, config *MonitorConfig, eventCb func(kemtypes.KubeEvent), logger *log.Logger) *monitor {
 	cctx, cancel := context.WithCancel(ctx)
 
+	// Ensure config.Logger is set: resource_informer and namespace_informer
+	// access MonitorConfig.Logger directly (ei.Monitor.Logger / ni.Monitor.Logger).
+	// Without this, a nil Logger causes a nil pointer dereference.
+	if config.Logger == nil {
+		config.Logger = logger
+	}
+
 	return &monitor{
 		ctx:               cctx,
 		cancel:            cancel,

--- a/pkg/kube_events_manager/monitor.go
+++ b/pkg/kube_events_manager/monitor.go
@@ -137,13 +137,6 @@ var _ Monitor = (*monitor)(nil)
 func NewMonitor(ctx context.Context, client *klient.Client, mstor metricsstorage.Storage, factoryStore *FactoryStore, config *MonitorConfig, eventCb func(kemtypes.KubeEvent), logger *log.Logger) *monitor {
 	cctx, cancel := context.WithCancel(ctx)
 
-	// Ensure config.Logger is set: resource_informer and namespace_informer
-	// access MonitorConfig.Logger directly (ei.Monitor.Logger / ni.Monitor.Logger).
-	// Without this, a nil Logger causes a nil pointer dereference.
-	if config.Logger == nil {
-		config.Logger = logger
-	}
-
 	return &monitor{
 		ctx:               cctx,
 		cancel:            cancel,
@@ -201,7 +194,7 @@ func (m *monitor) CreateInformers() error {
 
 	if m.Config.NamespaceSelector != nil && m.Config.NamespaceSelector.LabelSelector != nil {
 		logEntry.Debug("Create NamespaceInformer for namespace.labelSelector")
-		m.NamespaceInformer = NewNamespaceInformer(m.ctx, m.KubeClient, m.Config)
+		m.NamespaceInformer = NewNamespaceInformer(m.ctx, m.KubeClient, m.Config, m.logger)
 		err := m.NamespaceInformer.createSharedInformer(
 			func(nsName string) {
 				// Added/Modified event: check, create and run informers for Ns

--- a/pkg/kube_events_manager/namespace_informer.go
+++ b/pkg/kube_events_manager/namespace_informer.go
@@ -37,9 +37,11 @@ type namespaceInformer struct {
 
 	addFn func(string)
 	delFn func(string)
+
+	logger *log.Logger
 }
 
-func NewNamespaceInformer(ctx context.Context, client *klient.Client, monitor *MonitorConfig) *namespaceInformer {
+func NewNamespaceInformer(ctx context.Context, client *klient.Client, monitor *MonitorConfig, logger *log.Logger) *namespaceInformer {
 	cctx, cancel := context.WithCancel(ctx)
 
 	informer := &namespaceInformer{
@@ -48,6 +50,7 @@ func NewNamespaceInformer(ctx context.Context, client *klient.Client, monitor *M
 		KubeClient:     client,
 		Monitor:        monitor,
 		ExistedObjects: make(map[string]bool),
+		logger:         logger,
 	}
 	return informer
 }
@@ -151,7 +154,7 @@ func (ni *namespaceInformer) start() {
 	if err := wait.PollUntilContextCancel(cctx, DefaultSyncTime, true, func(_ context.Context) (bool, error) {
 		return ni.SharedInformer.HasSynced(), nil
 	}); err != nil {
-		ni.Monitor.Logger.Error("Cache is not synced for informer",
+		ni.logger.Error("Cache is not synced for informer",
 			slog.String(pkg.LogKeyDebugName, ni.Monitor.Metadata.DebugName))
 	}
 

--- a/pkg/kube_events_manager/resource_informer.go
+++ b/pkg/kube_events_manager/resource_informer.go
@@ -465,7 +465,7 @@ func (ei *resourceInformer) start() {
 	errorHandler := newWatchErrorHandler(ei.Monitor.Metadata.DebugName, ei.Monitor.Kind, ei.Monitor.Metadata.LogLabels, ei.metricStorage, ei.logger.Named("watch-error-handler"))
 	err := ei.factoryStore.Start(ei.ctx, ei.id, ei.KubeClient.Dynamic(), ei.FactoryIndex, ei, errorHandler)
 	if err != nil {
-		ei.Monitor.Logger.Error("cache is not synced for informer", slog.String(pkg.LogKeyDebugName, ei.Monitor.Metadata.DebugName))
+		ei.logger.Error("cache is not synced for informer", slog.String(pkg.LogKeyDebugName, ei.Monitor.Metadata.DebugName))
 		return
 	}
 

--- a/pkg/shell-operator/bootstrap.go
+++ b/pkg/shell-operator/bootstrap.go
@@ -3,6 +3,8 @@ package shell_operator
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"time"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
 	metricsstorage "github.com/deckhouse/deckhouse/pkg/metrics-storage"
@@ -239,18 +241,52 @@ func (op *ShellOperator) assembleShellOperator(cfg *app.Config, hooksDir string,
 	}
 
 	// Load validation hooks.
-	err = op.initValidatingWebhookManager()
+	// Retry with backoff: a brief API server blip during startup should not
+	// cause a fatal crash and a long CrashLoopBackOff cycle.
+	err = retryWithBackoff(op.logger, "ValidatingWebhookManager", op.initValidatingWebhookManager)
 	if err != nil {
 		return fmt.Errorf("initialize ValidatingWebhookManager fail: %w", err)
 	}
 
 	// Load conversion hooks.
-	err = op.initConversionWebhookManager()
+	err = retryWithBackoff(op.logger, "ConversionWebhookManager", op.initConversionWebhookManager)
 	if err != nil {
 		return fmt.Errorf("initialize ConversionWebhookManager fail: %w", err)
 	}
 
 	return nil
+}
+
+const (
+	webhookInitMaxRetries     = 8
+	webhookInitMinBackoff     = 1 * time.Second
+	webhookInitMaxBackoff     = 15 * time.Second
+	webhookInitTotalBudgetStr = "~2 min"
+)
+
+// retryWithBackoff retries fn with exponential backoff. It is used to tolerate
+// brief API server unavailability during webhook manager initialization so the
+// process does not exit fatally and enter a long CrashLoopBackOff cycle.
+func retryWithBackoff(logger *log.Logger, name string, fn func() error) error {
+	backoff := webhookInitMinBackoff
+	var lastErr error
+	for attempt := 0; attempt <= webhookInitMaxRetries; attempt++ {
+		lastErr = fn()
+		if lastErr == nil {
+			return nil
+		}
+		if attempt < webhookInitMaxRetries {
+			logger.Warn("webhook manager init failed, retrying",
+				slog.String("manager", name),
+				slog.Int("attempt", attempt+1),
+				slog.Duration("backoff", backoff),
+				slog.String("budget", webhookInitTotalBudgetStr),
+				log.Err(lastErr))
+			time.Sleep(backoff)
+			backoff = min(backoff*2, webhookInitMaxBackoff)
+		}
+	}
+	return lastErr
 }
 
 // SetupEventManagers instantiate queues and managers for schedule and Kubernetes events.

--- a/pkg/shell-operator/bootstrap.go
+++ b/pkg/shell-operator/bootstrap.go
@@ -3,7 +3,6 @@ package shell_operator
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"time"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
@@ -19,6 +18,7 @@ import (
 	schedulemanager "github.com/flant/shell-operator/pkg/schedule_manager"
 	"github.com/flant/shell-operator/pkg/task/queue"
 	utils "github.com/flant/shell-operator/pkg/utils/file"
+	"github.com/flant/shell-operator/pkg/utils/retry"
 	"github.com/flant/shell-operator/pkg/webhook/admission"
 	"github.com/flant/shell-operator/pkg/webhook/conversion"
 	webhookserver "github.com/flant/shell-operator/pkg/webhook/server"
@@ -243,13 +243,13 @@ func (op *ShellOperator) assembleShellOperator(cfg *app.Config, hooksDir string,
 	// Load validation hooks.
 	// Retry with backoff: a brief API server blip during startup should not
 	// cause a fatal crash and a long CrashLoopBackOff cycle.
-	err = retryWithBackoff(op.logger, "ValidatingWebhookManager", op.initValidatingWebhookManager)
+	err = retry.WithBackoff(op.ctx, webhookInitRetryConfig, op.logger, "ValidatingWebhookManager", op.initValidatingWebhookManager)
 	if err != nil {
 		return fmt.Errorf("initialize ValidatingWebhookManager fail: %w", err)
 	}
 
 	// Load conversion hooks.
-	err = retryWithBackoff(op.logger, "ConversionWebhookManager", op.initConversionWebhookManager)
+	err = retry.WithBackoff(op.ctx, webhookInitRetryConfig, op.logger, "ConversionWebhookManager", op.initConversionWebhookManager)
 	if err != nil {
 		return fmt.Errorf("initialize ConversionWebhookManager fail: %w", err)
 	}
@@ -258,35 +258,19 @@ func (op *ShellOperator) assembleShellOperator(cfg *app.Config, hooksDir string,
 }
 
 const (
-	webhookInitMaxRetries     = 8
-	webhookInitMinBackoff     = 1 * time.Second
-	webhookInitMaxBackoff     = 15 * time.Second
-	webhookInitTotalBudgetStr = "~2 min"
+	// webhookInitMaxRetries controls how many times webhook manager init is
+	// retried during startup.  maxRetries=8 + initialBackoff=1 s + maxBackoff=15 s
+	// yields ~75 s of sleep plus call execution time (not a hard wall-clock
+	// budget — for that, use a context deadline).
+	webhookInitMaxRetries = 8
+	webhookInitMinBackoff = 1 * time.Second
+	webhookInitMaxBackoff = 15 * time.Second
 )
 
-// retryWithBackoff retries fn with exponential backoff. It is used to tolerate
-// brief API server unavailability during webhook manager initialization so the
-// process does not exit fatally and enter a long CrashLoopBackOff cycle.
-func retryWithBackoff(logger *log.Logger, name string, fn func() error) error {
-	backoff := webhookInitMinBackoff
-	var lastErr error
-	for attempt := 0; attempt <= webhookInitMaxRetries; attempt++ {
-		lastErr = fn()
-		if lastErr == nil {
-			return nil
-		}
-		if attempt < webhookInitMaxRetries {
-			logger.Warn("webhook manager init failed, retrying",
-				slog.String("manager", name),
-				slog.Int("attempt", attempt+1),
-				slog.Duration("backoff", backoff),
-				slog.String("budget", webhookInitTotalBudgetStr),
-				log.Err(lastErr))
-			time.Sleep(backoff)
-			backoff = min(backoff*2, webhookInitMaxBackoff)
-		}
-	}
-	return lastErr
+var webhookInitRetryConfig = retry.Config{
+	MaxRetries:     webhookInitMaxRetries,
+	InitialBackoff: webhookInitMinBackoff,
+	MaxBackoff:     webhookInitMaxBackoff,
 }
 
 // SetupEventManagers instantiate queues and managers for schedule and Kubernetes events.

--- a/pkg/shell-operator/bootstrap.go
+++ b/pkg/shell-operator/bootstrap.go
@@ -3,7 +3,6 @@ package shell_operator
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
 	metricsstorage "github.com/deckhouse/deckhouse/pkg/metrics-storage"
@@ -18,7 +17,6 @@ import (
 	schedulemanager "github.com/flant/shell-operator/pkg/schedule_manager"
 	"github.com/flant/shell-operator/pkg/task/queue"
 	utils "github.com/flant/shell-operator/pkg/utils/file"
-	"github.com/flant/shell-operator/pkg/utils/retry"
 	"github.com/flant/shell-operator/pkg/webhook/admission"
 	"github.com/flant/shell-operator/pkg/webhook/conversion"
 	webhookserver "github.com/flant/shell-operator/pkg/webhook/server"
@@ -241,36 +239,18 @@ func (op *ShellOperator) assembleShellOperator(cfg *app.Config, hooksDir string,
 	}
 
 	// Load validation hooks.
-	// Retry with backoff: a brief API server blip during startup should not
-	// cause a fatal crash and a long CrashLoopBackOff cycle.
-	err = retry.WithBackoff(op.ctx, webhookInitRetryConfig, op.logger, "ValidatingWebhookManager", op.initValidatingWebhookManager)
+	err = op.initValidatingWebhookManager()
 	if err != nil {
 		return fmt.Errorf("initialize ValidatingWebhookManager fail: %w", err)
 	}
 
 	// Load conversion hooks.
-	err = retry.WithBackoff(op.ctx, webhookInitRetryConfig, op.logger, "ConversionWebhookManager", op.initConversionWebhookManager)
+	err = op.initConversionWebhookManager()
 	if err != nil {
 		return fmt.Errorf("initialize ConversionWebhookManager fail: %w", err)
 	}
 
 	return nil
-}
-
-const (
-	// webhookInitMaxRetries controls how many times webhook manager init is
-	// retried during startup.  maxRetries=8 + initialBackoff=1 s + maxBackoff=15 s
-	// yields ~75 s of sleep plus call execution time (not a hard wall-clock
-	// budget — for that, use a context deadline).
-	webhookInitMaxRetries = 8
-	webhookInitMinBackoff = 1 * time.Second
-	webhookInitMaxBackoff = 15 * time.Second
-)
-
-var webhookInitRetryConfig = retry.Config{
-	MaxRetries:     webhookInitMaxRetries,
-	InitialBackoff: webhookInitMinBackoff,
-	MaxBackoff:     webhookInitMaxBackoff,
 }
 
 // SetupEventManagers instantiate queues and managers for schedule and Kubernetes events.

--- a/pkg/shell-operator/operator.go
+++ b/pkg/shell-operator/operator.go
@@ -230,7 +230,7 @@ func (op *ShellOperator) initValidatingWebhookManager() error {
 	admissionHandler := NewAdmissionEventHandler(op.HookManager, op.taskHandler, op.logger)
 	op.AdmissionWebhookManager.WithAdmissionEventHandler(admissionHandler.Handle)
 
-	if err := op.AdmissionWebhookManager.Start(); err != nil {
+	if err := op.AdmissionWebhookManager.Start(op.ctx); err != nil {
 		return fmt.Errorf("ValidatingWebhookManager start: %w", err)
 	}
 

--- a/pkg/utils/retry/retry.go
+++ b/pkg/utils/retry/retry.go
@@ -1,0 +1,54 @@
+// Package retry provides context-aware retry-with-backoff utilities.
+package retry
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
+)
+
+// Config controls the parameters for [RetryWithBackoff].
+type Config struct {
+	// MaxRetries is the maximum number of retry attempts (not counting the
+	// initial call).  The total number of calls to fn is MaxRetries+1.
+	MaxRetries int
+	// InitialBackoff is the delay before the first retry; it doubles on each
+	// consecutive failure up to MaxBackoff.
+	InitialBackoff time.Duration
+	// MaxBackoff caps the exponential backoff delay.
+	MaxBackoff time.Duration
+}
+
+// RetryWithBackoff retries fn with exponential backoff, honouring ctx
+// cancellation during sleep intervals.  The caller label is used in log
+// messages.  Returns the last error from fn if all attempts fail, or nil on
+// success.  If ctx is cancelled during a backoff sleep, ctx.Err() is returned
+// immediately.
+func WithBackoff(ctx context.Context, cfg Config, logger *log.Logger, caller string, fn func() error) error {
+	backoff := cfg.InitialBackoff
+	var lastErr error
+	for attempt := 0; attempt <= cfg.MaxRetries; attempt++ {
+		lastErr = fn()
+		if lastErr == nil {
+			return nil
+		}
+		if attempt < cfg.MaxRetries {
+			logger.Warn("retrying after failure",
+				slog.String("caller", caller),
+				slog.Int("attempt", attempt+1),
+				slog.Duration("backoff", backoff),
+				log.Err(lastErr))
+
+			select {
+			case <-time.After(backoff):
+			case <-ctx.Done():
+				return fmt.Errorf("context cancelled during backoff: %w", ctx.Err())
+			}
+			backoff = min(backoff*2, cfg.MaxBackoff)
+		}
+	}
+	return lastErr
+}

--- a/pkg/utils/retry/retry.go
+++ b/pkg/utils/retry/retry.go
@@ -10,7 +10,7 @@ import (
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
-// Config controls the parameters for [RetryWithBackoff].
+// Config controls the parameters for [WithBackoff].
 type Config struct {
 	// MaxRetries is the maximum number of retry attempts (not counting the
 	// initial call).  The total number of calls to fn is MaxRetries+1.
@@ -22,7 +22,7 @@ type Config struct {
 	MaxBackoff time.Duration
 }
 
-// RetryWithBackoff retries fn with exponential backoff, honouring ctx
+// WithBackoff retries fn with exponential backoff, honouring ctx
 // cancellation during sleep intervals.  The caller label is used in log
 // messages.  Returns the last error from fn if all attempts fail, or nil on
 // success.  If ctx is cancelled during a backoff sleep, ctx.Err() is returned

--- a/pkg/utils/retry/retry_test.go
+++ b/pkg/utils/retry/retry_test.go
@@ -1,0 +1,80 @@
+package retry
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRetryWithBackoff_Success(t *testing.T) {
+	cfg := Config{
+		MaxRetries:     3,
+		InitialBackoff: 10 * time.Millisecond,
+		MaxBackoff:     50 * time.Millisecond,
+	}
+	callCount := 0
+	fn := func() error {
+		callCount++
+		if callCount < 2 {
+			return errors.New("transient")
+		}
+		return nil
+	}
+
+	err := WithBackoff(context.Background(), cfg, log.NewNop(), "test", fn)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, callCount)
+}
+
+func TestRetryWithBackoff_Exhausted(t *testing.T) {
+	cfg := Config{
+		MaxRetries:     2,
+		InitialBackoff: 10 * time.Millisecond,
+		MaxBackoff:     50 * time.Millisecond,
+	}
+	fn := func() error { return errors.New("fail") }
+
+	err := WithBackoff(context.Background(), cfg, log.NewNop(), "test", fn)
+	assert.Error(t, err)
+	assert.EqualError(t, err, "fail")
+}
+
+func TestRetryWithBackoff_ContextCancelled(t *testing.T) {
+	cfg := Config{
+		MaxRetries:     5,
+		InitialBackoff: 200 * time.Millisecond,
+		MaxBackoff:     1 * time.Second,
+	}
+	fn := func() error { return errors.New("fail") }
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	err := WithBackoff(ctx, cfg, log.NewNop(), "test", fn)
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, context.DeadlineExceeded), "expected DeadlineExceeded, got: %v", err)
+}
+
+func TestRetryWithBackoff_BackoffCapsAtMax(t *testing.T) {
+	cfg := Config{
+		MaxRetries:     5,
+		InitialBackoff: 10 * time.Millisecond,
+		MaxBackoff:     20 * time.Millisecond,
+	}
+	attempts := 0
+	fn := func() error {
+		attempts++
+		if attempts == 4 {
+			return nil
+		}
+		return errors.New("fail")
+	}
+
+	err := WithBackoff(context.Background(), cfg, log.NewNop(), "test", fn)
+	assert.NoError(t, err)
+	assert.Equal(t, 4, attempts)
+}

--- a/pkg/webhook/admission/manager.go
+++ b/pkg/webhook/admission/manager.go
@@ -1,6 +1,7 @@
 package admission
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -138,21 +139,21 @@ func (m *WebhookManager) AddMutatingWebhook(config *MutatingWebhookConfig) {
 	r.Set(config)
 }
 
-func (m *WebhookManager) Start() error {
+func (m *WebhookManager) Start(ctx context.Context) error {
 	err := m.Server.Start()
 	if err != nil {
 		return fmt.Errorf("start webhook server: %w", err)
 	}
 
 	for _, r := range m.ValidatingResources {
-		err = r.Register()
+		err = r.Register(ctx)
 		if err != nil {
 			return fmt.Errorf("register validating webhook: %w", err)
 		}
 	}
 
 	for _, r := range m.MutatingResources {
-		err = r.Register()
+		err = r.Register(ctx)
 		if err != nil {
 			return fmt.Errorf("register mutating webhook: %w", err)
 		}

--- a/pkg/webhook/admission/resource.go
+++ b/pkg/webhook/admission/resource.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
 	v1 "k8s.io/api/admissionregistration/v1"
@@ -12,6 +13,17 @@ import (
 
 	klient "github.com/flant/kube-client/client"
 	"github.com/flant/shell-operator/pkg"
+)
+
+const (
+	// submitMaxRetries is the number of retry attempts for webhook configuration
+	// registration against the API server. Brief API server unavailability (e.g.
+	// during rolling restarts or leader election) should not cause a fatal exit.
+	submitMaxRetries = 5
+	// submitInitialBackoff is the initial delay between retries. It doubles on
+	// each consecutive failure up to submitMaxBackoff.
+	submitInitialBackoff = 2 * time.Second
+	submitMaxBackoff     = 15 * time.Second
 )
 
 type WebhookResourceOptions struct {
@@ -103,10 +115,27 @@ func (w *ValidatingWebhookResource) submit(conf *v1.ValidatingWebhookConfigurati
 	listOpts := metav1.ListOptions{
 		FieldSelector: "metadata.name=" + conf.Name,
 	}
-	list, err := client.List(context.TODO(), listOpts)
-	if err != nil {
+
+	var list *v1.ValidatingWebhookConfigurationList
+	var err error
+	backoff := submitInitialBackoff
+	for attempt := 0; attempt <= submitMaxRetries; attempt++ {
+		list, err = client.List(context.TODO(), listOpts)
+		if err == nil {
+			break
+		}
+		if attempt < submitMaxRetries {
+			logger.Warn("list ValidatingWebhookConfiguration failed, retrying",
+				log.Err(err),
+				slog.Int("attempt", attempt+1),
+				slog.Duration("backoff", backoff))
+			time.Sleep(backoff)
+			backoff = min(backoff*2, submitMaxBackoff)
+			continue
+		}
 		return fmt.Errorf("list ValidatingWebhookConfiguration: %w", err)
 	}
+
 	if len(list.Items) == 0 {
 		_, err = client.Create(context.TODO(), conf, pkg.DefaultCreateOptions())
 		if err != nil {
@@ -187,10 +216,27 @@ func (w *MutatingWebhookResource) submit(conf *v1.MutatingWebhookConfiguration) 
 	listOpts := metav1.ListOptions{
 		FieldSelector: "metadata.name=" + conf.Name,
 	}
-	list, err := client.List(context.TODO(), listOpts)
-	if err != nil {
+
+	var list *v1.MutatingWebhookConfigurationList
+	var err error
+	backoff := submitInitialBackoff
+	for attempt := 0; attempt <= submitMaxRetries; attempt++ {
+		list, err = client.List(context.TODO(), listOpts)
+		if err == nil {
+			break
+		}
+		if attempt < submitMaxRetries {
+			logger.Warn("list MutatingWebhookConfiguration failed, retrying",
+				log.Err(err),
+				slog.Int("attempt", attempt+1),
+				slog.Duration("backoff", backoff))
+			time.Sleep(backoff)
+			backoff = min(backoff*2, submitMaxBackoff)
+			continue
+		}
 		return fmt.Errorf("list MutatingWebhookConfiguration: %w", err)
 	}
+
 	if len(list.Items) == 0 {
 		_, err = client.Create(context.TODO(), conf, pkg.DefaultCreateOptions())
 		if err != nil {

--- a/pkg/webhook/admission/resource.go
+++ b/pkg/webhook/admission/resource.go
@@ -13,18 +13,30 @@ import (
 
 	klient "github.com/flant/kube-client/client"
 	"github.com/flant/shell-operator/pkg"
+	"github.com/flant/shell-operator/pkg/utils/retry"
 )
 
 const (
 	// submitMaxRetries is the number of retry attempts for webhook configuration
 	// registration against the API server. Brief API server unavailability (e.g.
 	// during rolling restarts or leader election) should not cause a fatal exit.
+	//
+	// Note: the bootstrap-level webhook-init retry (8 attempts, 1 s initial backoff)
+	// wraps this submit-level retry (5 attempts, 2 s initial backoff).  The two
+	// layers stack but serve different purposes — outer retries the full manager
+	// init; inner retries only the API server registration call.
 	submitMaxRetries = 5
 	// submitInitialBackoff is the initial delay between retries. It doubles on
 	// each consecutive failure up to submitMaxBackoff.
 	submitInitialBackoff = 2 * time.Second
 	submitMaxBackoff     = 15 * time.Second
 )
+
+var submitRetryConfig = retry.Config{
+	MaxRetries:     submitMaxRetries,
+	InitialBackoff: submitInitialBackoff,
+	MaxBackoff:     submitMaxBackoff,
+}
 
 type WebhookResourceOptions struct {
 	KubeClient        *klient.Client
@@ -57,7 +69,7 @@ func (w *ValidatingWebhookResource) Get(id string) *ValidatingWebhookConfig {
 	return w.hooks[id]
 }
 
-func (w *ValidatingWebhookResource) Register() error {
+func (w *ValidatingWebhookResource) Register(ctx context.Context) error {
 	configuration := &v1.ValidatingWebhookConfiguration{
 		Webhooks: []v1.ValidatingWebhook{},
 	}
@@ -83,7 +95,7 @@ func (w *ValidatingWebhookResource) Register() error {
 		configuration.Webhooks = append(configuration.Webhooks, *webhook.ValidatingWebhook)
 	}
 
-	return w.submit(configuration)
+	return w.submit(ctx, configuration)
 }
 
 func (w *ValidatingWebhookResource) Unregister() error {
@@ -108,48 +120,31 @@ func createWebhookPath(webhook IWebhookConfig) *string {
 	return &res
 }
 
-func (w *ValidatingWebhookResource) submit(conf *v1.ValidatingWebhookConfiguration) error {
-	logger := w.logger.With(slog.String(pkg.LogKeyName, conf.Name))
+func (w *ValidatingWebhookResource) submit(ctx context.Context, conf *v1.ValidatingWebhookConfiguration) error {
 	client := w.opts.KubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations()
-
 	listOpts := metav1.ListOptions{
 		FieldSelector: "metadata.name=" + conf.Name,
 	}
 
-	var list *v1.ValidatingWebhookConfigurationList
-	var err error
-	backoff := submitInitialBackoff
-	for attempt := 0; attempt <= submitMaxRetries; attempt++ {
-		list, err = client.List(context.TODO(), listOpts)
-		if err == nil {
-			break
-		}
-		if attempt < submitMaxRetries {
-			logger.Warn("list ValidatingWebhookConfiguration failed, retrying",
-				log.Err(err),
-				slog.Int("attempt", attempt+1),
-				slog.Duration("backoff", backoff))
-			time.Sleep(backoff)
-			backoff = min(backoff*2, submitMaxBackoff)
-			continue
-		}
-		return fmt.Errorf("list ValidatingWebhookConfiguration: %w", err)
-	}
-
-	if len(list.Items) == 0 {
-		_, err = client.Create(context.TODO(), conf, pkg.DefaultCreateOptions())
-		if err != nil {
-			logger.Error("Create ValidatingWebhookConfiguration", log.Err(err))
-		}
-	} else {
-		newConf := list.Items[0]
-		newConf.Webhooks = conf.Webhooks
-		_, err = client.Update(context.TODO(), &newConf, pkg.DefaultUpdateOptions())
-		if err != nil {
-			logger.Error("Replace ValidatingWebhookConfiguration", log.Err(err))
-		}
-	}
-	return nil
+	return retry.WithBackoff(ctx, submitRetryConfig, w.logger.With(slog.String(pkg.LogKeyName, conf.Name)),
+		"ValidatingWebhookConfiguration/submit", func() error {
+			list, err := client.List(ctx, listOpts)
+			if err != nil {
+				return fmt.Errorf("list ValidatingWebhookConfiguration: %w", err)
+			}
+			if len(list.Items) == 0 {
+				if _, err := client.Create(ctx, conf, pkg.DefaultCreateOptions()); err != nil {
+					return fmt.Errorf("create ValidatingWebhookConfiguration: %w", err)
+				}
+			} else {
+				newConf := list.Items[0]
+				newConf.Webhooks = conf.Webhooks
+				if _, err := client.Update(ctx, &newConf, pkg.DefaultUpdateOptions()); err != nil {
+					return fmt.Errorf("update ValidatingWebhookConfiguration: %w", err)
+				}
+			}
+			return nil
+		})
 }
 
 type MutatingWebhookResource struct {
@@ -175,7 +170,7 @@ func (w *MutatingWebhookResource) Get(id string) *MutatingWebhookConfig {
 	return w.hooks[id]
 }
 
-func (w *MutatingWebhookResource) Register() error {
+func (w *MutatingWebhookResource) Register(ctx context.Context) error {
 	configuration := &v1.MutatingWebhookConfiguration{
 		Webhooks: []v1.MutatingWebhook{},
 	}
@@ -201,7 +196,7 @@ func (w *MutatingWebhookResource) Register() error {
 		configuration.Webhooks = append(configuration.Webhooks, *webhook.MutatingWebhook)
 	}
 
-	return w.submit(configuration)
+	return w.submit(ctx, configuration)
 }
 
 func (w *MutatingWebhookResource) Unregister() error {
@@ -209,46 +204,29 @@ func (w *MutatingWebhookResource) Unregister() error {
 		Delete(context.TODO(), w.opts.ConfigurationName, metav1.DeleteOptions{})
 }
 
-func (w *MutatingWebhookResource) submit(conf *v1.MutatingWebhookConfiguration) error {
-	logger := w.logger.With(slog.String(pkg.LogKeyName, conf.Name))
+func (w *MutatingWebhookResource) submit(ctx context.Context, conf *v1.MutatingWebhookConfiguration) error {
 	client := w.opts.KubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations()
-
 	listOpts := metav1.ListOptions{
 		FieldSelector: "metadata.name=" + conf.Name,
 	}
 
-	var list *v1.MutatingWebhookConfigurationList
-	var err error
-	backoff := submitInitialBackoff
-	for attempt := 0; attempt <= submitMaxRetries; attempt++ {
-		list, err = client.List(context.TODO(), listOpts)
-		if err == nil {
-			break
-		}
-		if attempt < submitMaxRetries {
-			logger.Warn("list MutatingWebhookConfiguration failed, retrying",
-				log.Err(err),
-				slog.Int("attempt", attempt+1),
-				slog.Duration("backoff", backoff))
-			time.Sleep(backoff)
-			backoff = min(backoff*2, submitMaxBackoff)
-			continue
-		}
-		return fmt.Errorf("list MutatingWebhookConfiguration: %w", err)
-	}
-
-	if len(list.Items) == 0 {
-		_, err = client.Create(context.TODO(), conf, pkg.DefaultCreateOptions())
-		if err != nil {
-			logger.Error("Create MutatingWebhookConfiguration", log.Err(err))
-		}
-	} else {
-		newConf := list.Items[0]
-		newConf.Webhooks = conf.Webhooks
-		_, err = client.Update(context.TODO(), &newConf, pkg.DefaultUpdateOptions())
-		if err != nil {
-			logger.Error("Replace MutatingWebhookConfiguration", log.Err(err))
-		}
-	}
-	return nil
+	return retry.WithBackoff(ctx, submitRetryConfig, w.logger.With(slog.String(pkg.LogKeyName, conf.Name)),
+		"MutatingWebhookConfiguration/submit", func() error {
+			list, err := client.List(ctx, listOpts)
+			if err != nil {
+				return fmt.Errorf("list MutatingWebhookConfiguration: %w", err)
+			}
+			if len(list.Items) == 0 {
+				if _, err := client.Create(ctx, conf, pkg.DefaultCreateOptions()); err != nil {
+					return fmt.Errorf("create MutatingWebhookConfiguration: %w", err)
+				}
+			} else {
+				newConf := list.Items[0]
+				newConf.Webhooks = conf.Webhooks
+				if _, err := client.Update(ctx, &newConf, pkg.DefaultUpdateOptions()); err != nil {
+					return fmt.Errorf("update MutatingWebhookConfiguration: %w", err)
+				}
+			}
+			return nil
+		})
 }

--- a/pkg/webhook/admission/resource.go
+++ b/pkg/webhook/admission/resource.go
@@ -21,10 +21,9 @@ const (
 	// registration against the API server. Brief API server unavailability (e.g.
 	// during rolling restarts or leader election) should not cause a fatal exit.
 	//
-	// Note: the bootstrap-level webhook-init retry (8 attempts, 1 s initial backoff)
-	// wraps this submit-level retry (5 attempts, 2 s initial backoff).  The two
-	// layers stack but serve different purposes — outer retries the full manager
-	// init; inner retries only the API server registration call.
+	// This retry is intentionally scoped to API-server registration calls only.
+	// Do not wrap full webhook-manager bootstrap with another retry layer: server
+	// Start() is not idempotent and may leave running listeners/goroutines.
 	submitMaxRetries = 5
 	// submitInitialBackoff is the initial delay between retries. It doubles on
 	// each consecutive failure up to submitMaxBackoff.


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Improve webhook registration resilience by adding context-aware retry with exponential backoff for admission webhook configuration submit calls, and harden kube-events informer error logging paths.

#### What this PR does / why we need it
During shell-operator startup, the admission webhook manager must register ValidatingWebhookConfiguration and MutatingWebhookConfiguration via the Kubernetes API.
If the API server is briefly unavailable (rolling restart, leader election, etcd hiccup), these calls could previously fail immediately and abort startup.

This PR adds resilience at the admission resource submit layer:

 - Adds retry with exponential backoff for submit operations of:
     - `ValidatingWebhookConfiguration`
     - `MutatingWebhookConfiguration`
 - Retry settings:
     - MaxRetries: 5 (up to 6 total attempts),
     - backoff from 2s up to 15s max,
     - retry loop is context-aware and stops on context cancellation.
 - `list`/`create`/`update` errors are now returned (fail-fast) instead of being logged and silently ignored.

 Additional hardening included in this PR:

 - WebhookManager.Start() now accepts context.Context and passes it into Register(ctx).
 - In kube_events_manager, error-path logging is made safer:
     - namespace_informer and resource_informer now use their own logger field instead of relying on MonitorConfig.Logger directly.
     - AddMonitor ensures MonitorConfig.Logger is initialized when missing.
 - Introduces reusable retry utility:
     - pkg/utils/retry/retry.go
     - with unit tests in pkg/utils/retry/retry_test.go.

