### PR TITLE
[shell-operator] chore: use deckhouse base images for build and runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Prebuilt jq from deckhouse base images (v1.0.40).
 FROM --platform=${TARGETPLATFORM:-linux/amd64} registry.deckhouse.io/container-factory@sha256:4b36dcf53c35b50e0afbc445232713aff15f788a61b832cd720bf9e88fc9fba8 AS libjq
 
-# Go builder stage (builder/golang-alpine, Go 1.26.4 on alpine 3.22).
-FROM --platform=${TARGETPLATFORM:-linux/amd64} registry.deckhouse.io/container-factory@sha256:193e8ed6cd7fc19015ab615ccf92d0fe02471e66e3e5abf560b3a87fb05bdb62 AS builder
+# Go builder stage (builder/golang-alpine, Go 1.25 on alpine 3.22).
+FROM --platform=${TARGETPLATFORM:-linux/amd64} registry.deckhouse.io/container-factory@sha256:9701f93cec25acec10837e2399f7fda7e4c23303bed6514bfa0ff692396f170b AS builder
 
 ARG appVersion=latest
 
@@ -58,7 +58,7 @@ RUN mkdir /hooks
 # Copy necessary files
 ADD frameworks/shell /frameworks/shell
 ADD shell_lib.sh /
-COPY --from=libjq /usr/bin/jq /usr/bin/jq
+COPY --from=libjq /bin/jq /usr/bin
 COPY --from=builder /app/shell-operator /
 
 # Set working directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-# Prebuilt jq.
-FROM --platform=${TARGETPLATFORM:-linux/amd64} flant/jq:b6be13d5-musl AS libjq
+# Prebuilt jq from deckhouse base images (v1.0.40).
+FROM --platform=${TARGETPLATFORM:-linux/amd64} registry.deckhouse.io/container-factory@sha256:4b36dcf53c35b50e0afbc445232713aff15f788a61b832cd720bf9e88fc9fba8 AS libjq
 
-# Go builder stage
-FROM --platform=${TARGETPLATFORM:-linux/amd64} golang:1.26.3-alpine3.23 AS builder
+# Go builder stage (builder/golang-alpine, Go 1.26.4 on alpine 3.22).
+FROM --platform=${TARGETPLATFORM:-linux/amd64} registry.deckhouse.io/container-factory@sha256:193e8ed6cd7fc19015ab615ccf92d0fe02471e66e3e5abf560b3a87fb05bdb62 AS builder
 
 ARG appVersion=latest
 
@@ -32,8 +32,8 @@ RUN GOOS=linux \
     -o shell-operator \
     ./cmd/shell-operator
 
-# Final runtime image
-FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine:3.23
+# Final runtime image (builder/alpine 3.22 from deckhouse base images v1.0.40).
+FROM --platform=${TARGETPLATFORM:-linux/amd64} registry.deckhouse.io/container-factory@sha256:8fa8cf713bf8cfc9038901e5b2fbc97d0403794d834dc4a619e9e81312a6feef
 
 ARG TARGETPLATFORM
 ARG kubectlVersion=v1.34.8
@@ -58,7 +58,7 @@ RUN mkdir /hooks
 # Copy necessary files
 ADD frameworks/shell /frameworks/shell
 ADD shell_lib.sh /
-COPY --from=libjq /bin/jq /usr/bin
+COPY --from=libjq /usr/bin/jq /usr/bin/jq
 COPY --from=builder /app/shell-operator /
 
 # Set working directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Prebuilt jq from deckhouse base images (v1.0.40).
 FROM --platform=${TARGETPLATFORM:-linux/amd64} registry.deckhouse.io/container-factory@sha256:4b36dcf53c35b50e0afbc445232713aff15f788a61b832cd720bf9e88fc9fba8 AS libjq
 
-# Go builder stage (builder/golang-alpine, Go 1.25 on alpine 3.22).
-FROM --platform=${TARGETPLATFORM:-linux/amd64} registry.deckhouse.io/container-factory@sha256:9701f93cec25acec10837e2399f7fda7e4c23303bed6514bfa0ff692396f170b AS builder
+# Go builder stage (builder/golang-alpine, Go 1.26.4 on alpine 3.22).
+FROM --platform=${TARGETPLATFORM:-linux/amd64} registry.deckhouse.io/container-factory@sha256:193e8ed6cd7fc19015ab615ccf92d0fe02471e66e3e5abf560b3a87fb05bdb62 AS builder
 
 ARG appVersion=latest
 


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

#### Overview

Migrate Dockerfile base images to container-factory

Replace public Docker Hub images (golang:*-alpine, alpine:*) and flant/jq with pinned Deckhouse container-factory base images (v1.0.40):

 - builder/golang-alpine (Go 1.26.4, alpine 3.22) for the build stage
 - builder/alpine (alpine 3.22) for the runtime stage
 - jq for the libjq stag

