### PR TITLE
[shell-operator] fix: isolate panics in ManagerEventsHandler callbacks, self-heal kubernetes bindings, own shared informer lifetime

### DIFF
--- a/pkg/hook/controller/hook_controller.go
+++ b/pkg/hook/controller/hook_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
+	metricsstorage "github.com/deckhouse/deckhouse/pkg/metrics-storage"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 	bctx "github.com/flant/shell-operator/pkg/hook/binding_context"
@@ -64,6 +65,11 @@ func (hc *HookController) InitKubernetesBindings(bindings []htypes.OnKubernetesE
 	bindingCtrl := NewKubernetesBindingsController(logger)
 	bindingCtrl.WithKubeEventsManager(kubeEventMgr)
 	bindingCtrl.WithKubernetesBindings(bindings)
+	// KubeEventsSource is a narrow interface; recover the metric storage from the
+	// real manager when available so the controller can count missing monitors.
+	if mgr, ok := kubeEventMgr.(interface{ MetricStorage() metricsstorage.Storage }); ok {
+		bindingCtrl.WithMetricStorage(mgr.MetricStorage())
+	}
 	hc.KubernetesController = bindingCtrl
 	hc.kubernetesBindings = bindings
 	hc.logger = logger

--- a/pkg/hook/controller/kubernetes_bindings_controller.go
+++ b/pkg/hook/controller/kubernetes_bindings_controller.go
@@ -79,31 +79,38 @@ func (c *kubernetesBindingsController) WithKubeEventsManager(kubeEventsManager k
 // EnableKubernetesBindings adds a monitor for each 'kubernetes' binding. This method
 // returns an array of BindingExecutionInfo to help construct initial tasks to run hooks.
 // Informers in each monitor are started immediately to keep up the "fresh" state of object caches.
+//
+// The method is idempotent and self-healing: per-binding monitor creation is guarded so a
+// second call does not create duplicate monitors, and a binding whose link exists but whose
+// monitor is missing (e.g. a monitor stopped out of band by DisableKubernetesBindings racing
+// with this call) is repaired by re-adding and re-starting the monitor. A Synchronization
+// BindingExecutionInfo is always returned for every binding, so a repeat call after a partial
+// failure never silently drops the Synchronization run that populates hook snapshots.
 func (c *kubernetesBindingsController) EnableKubernetesBindings() ([]BindingExecutionInfo, error) {
 	res := make([]BindingExecutionInfo, 0)
 
-	c.l.RLock()
-	alreadyEnabled := len(c.BindingMonitorLinks) == len(c.KubernetesBindings)
-	c.l.RUnlock()
-	if alreadyEnabled {
-		return res, nil
-	}
-
 	for _, config := range c.KubernetesBindings {
-		if _, found := c.getBindingMonitorLinksById(config.Monitor.Metadata.MonitorId); !found {
+		monitorID := config.Monitor.Metadata.MonitorId
+
+		_, linked := c.getBindingMonitorLinksById(monitorID)
+		// Add the monitor when there is no link yet, or when the link exists but the
+		// monitor is gone — the latter is the state a Disable/Enable race leaves behind
+		// and, without repair here, every later snapshot read for this binding returns
+		// empty while the hook still "succeeds".
+		if !linked || !c.kubeEventsManager.HasMonitor(monitorID) {
 			if err := c.kubeEventsManager.AddMonitor(config.Monitor); err != nil {
 				return nil, fmt.Errorf("run monitor: %s", err)
 			}
-			c.setBindingMonitorLinks(config.Monitor.Metadata.MonitorId, &KubernetesBindingToMonitorLink{
-				MonitorId:     config.Monitor.Metadata.MonitorId,
+			c.setBindingMonitorLinks(monitorID, &KubernetesBindingToMonitorLink{
+				MonitorId:     monitorID,
 				BindingConfig: config,
 			})
 			// Start monitor's informers to fill the cache.
-			c.kubeEventsManager.StartMonitor(config.Monitor.Metadata.MonitorId)
+			c.kubeEventsManager.StartMonitor(monitorID)
 		}
 
 		synchronizationInfo := c.HandleEvent(context.TODO(), kemtypes.KubeEvent{
-			MonitorId: config.Monitor.Metadata.MonitorId,
+			MonitorId: monitorID,
 			Type:      kemtypes.TypeSynchronization,
 		})
 		res = append(res, synchronizationInfo)
@@ -275,6 +282,15 @@ func (c *kubernetesBindingsController) SnapshotsFor(bindingName string) []kemtyp
 			if c.kubeEventsManager.HasMonitor(monitorID) {
 				return c.kubeEventsManager.GetMonitor(monitorID).Snapshot()
 			}
+
+			// A configured binding without a live monitor yields an empty snapshot while the
+			// hook still runs successfully — this is exactly how a lost/never-started monitor
+			// silently feeds empty values into a hook. Make it observable instead of silent;
+			// EnableKubernetesBindings repairs the state on the next module run.
+			c.logger.Warn("no monitor for configured kubernetes binding, snapshot is empty",
+				slog.String(pkg.LogKeyBinding, bindingName),
+				slog.String("monitorID", monitorID))
+			return nil
 		}
 	}
 

--- a/pkg/hook/controller/kubernetes_bindings_controller.go
+++ b/pkg/hook/controller/kubernetes_bindings_controller.go
@@ -7,12 +7,14 @@ import (
 	"sync"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
+	metricsstorage "github.com/deckhouse/deckhouse/pkg/metrics-storage"
 
 	"github.com/flant/shell-operator/pkg"
 	bctx "github.com/flant/shell-operator/pkg/hook/binding_context"
 	htypes "github.com/flant/shell-operator/pkg/hook/types"
 	kubeeventsmanager "github.com/flant/shell-operator/pkg/kube_events_manager"
 	kemtypes "github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	"github.com/flant/shell-operator/pkg/metrics"
 	utils "github.com/flant/shell-operator/pkg/utils/labels"
 )
 
@@ -49,6 +51,8 @@ type kubernetesBindingsController struct {
 
 	// dependencies
 	kubeEventsManager kubeeventsmanager.KubeEventsSource
+	// optional, only for the binding_monitor_missing_total counter
+	metricStorage metricsstorage.Storage
 
 	logger *log.Logger
 
@@ -74,6 +78,12 @@ func (c *kubernetesBindingsController) WithKubernetesBindings(bindings []htypes.
 
 func (c *kubernetesBindingsController) WithKubeEventsManager(kubeEventsManager kubeeventsmanager.KubeEventsSource) {
 	c.kubeEventsManager = kubeEventsManager
+}
+
+// WithMetricStorage sets an optional storage for the binding_monitor_missing_total
+// counter. Without it the missing-monitor state is still logged, just not counted.
+func (c *kubernetesBindingsController) WithMetricStorage(mstor metricsstorage.Storage) {
+	c.metricStorage = mstor
 }
 
 // EnableKubernetesBindings adds a monitor for each 'kubernetes' binding. This method
@@ -287,9 +297,13 @@ func (c *kubernetesBindingsController) SnapshotsFor(bindingName string) []kemtyp
 			// hook still runs successfully — this is exactly how a lost/never-started monitor
 			// silently feeds empty values into a hook. Make it observable instead of silent;
 			// EnableKubernetesBindings repairs the state on the next module run.
-			c.logger.Warn("no monitor for configured kubernetes binding, snapshot is empty",
+			c.logger.Error("no monitor for configured kubernetes binding, snapshot is empty",
 				slog.String(pkg.LogKeyBinding, bindingName),
-				slog.String("monitorID", monitorID))
+				slog.String(pkg.LogKeyMonitorID, monitorID))
+			if c.metricStorage != nil {
+				c.metricStorage.CounterAdd(metrics.BindingMonitorMissingTotal, 1.0,
+					map[string]string{pkg.MetricKeyBinding: bindingName})
+			}
 			return nil
 		}
 	}

--- a/pkg/hook/controller/kubernetes_bindings_controller_test.go
+++ b/pkg/hook/controller/kubernetes_bindings_controller_test.go
@@ -1,0 +1,89 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
+	. "github.com/onsi/gomega"
+
+	"github.com/flant/kube-client/fake"
+	"github.com/flant/shell-operator/pkg/hook/config"
+	kubeeventsmanager "github.com/flant/shell-operator/pkg/kube_events_manager"
+)
+
+const twoBindingsHookConfig = `
+configVersion: v1
+kubernetes:
+- name: binding_1
+  apiVersion: v1
+  kind: Pod
+  executeHookOnEvent: ["Added"]
+- name: binding_2
+  apiVersion: v1
+  kind: Pod
+  executeHookOnEvent: ["Added"]
+`
+
+func newTestKubeController(t *testing.T) (*HookController, *config.HookConfig, kubeeventsmanager.KubeEventsManager) {
+	t.Helper()
+	g := NewWithT(t)
+
+	fc := fake.NewFakeCluster(fake.ClusterVersionV121)
+	mgr := kubeeventsmanager.NewKubeEventsManager(context.Background(), fc.Client, log.NewNop())
+
+	cfg := &config.HookConfig{}
+	g.Expect(cfg.LoadAndValidate([]byte(twoBindingsHookConfig))).ShouldNot(HaveOccurred())
+
+	hc := NewHookController()
+	hc.InitKubernetesBindings(cfg.OnKubernetesEvents, mgr, log.NewNop())
+
+	return hc, cfg, mgr
+}
+
+// TestEnableKubernetesBindings_RepeatCallStillEmitsSynchronization is the direct
+// regression test for the incident: on the second call the old code hit the
+// alreadyEnabled early-return and yielded ZERO Synchronization contexts, so a
+// ModuleRun retry lost the values-populating Synchronization run for the module's
+// hooks. The fix must return a Synchronization context for every binding on every
+// call.
+func TestEnableKubernetesBindings_RepeatCallStillEmitsSynchronization(t *testing.T) {
+	g := NewWithT(t)
+	hc, cfg, _ := newTestKubeController(t)
+	want := len(cfg.OnKubernetesEvents)
+
+	first, err := hc.KubernetesController.EnableKubernetesBindings()
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(first).To(HaveLen(want), "first call must emit a Synchronization context per binding")
+
+	second, err := hc.KubernetesController.EnableKubernetesBindings()
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(second).To(HaveLen(want), "repeat call must still emit Synchronization contexts (regression: was 0)")
+}
+
+// TestEnableKubernetesBindings_SelfHealsMissingMonitor reproduces the permanent
+// "link present, monitor gone" state left by a Disable/Enable race and asserts
+// that a subsequent EnableKubernetesBindings repairs it — restoring the
+// self-healing behavior that existed before the idempotent early-return was added.
+func TestEnableKubernetesBindings_SelfHealsMissingMonitor(t *testing.T) {
+	g := NewWithT(t)
+	hc, cfg, mgr := newTestKubeController(t)
+
+	_, err := hc.KubernetesController.EnableKubernetesBindings()
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	// Drop a monitor out of band while its binding link stays — this is the state
+	// DisableKubernetesBindings racing with the queue worker leaves behind.
+	victim := cfg.OnKubernetesEvents[0].Monitor.Metadata.MonitorId
+	g.Expect(mgr.HasMonitor(victim)).To(BeTrue())
+	g.Expect(mgr.StopMonitor(victim)).ShouldNot(HaveOccurred())
+	g.Expect(mgr.HasMonitor(victim)).To(BeFalse())
+
+	// Snapshot for the orphaned binding is empty here — the silent-failure state.
+	g.Expect(hc.KubernetesController.SnapshotsFor(cfg.OnKubernetesEvents[0].BindingName)).To(BeNil())
+
+	// Next enable must re-create the monitor rather than early-return.
+	_, err = hc.KubernetesController.EnableKubernetesBindings()
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(mgr.HasMonitor(victim)).To(BeTrue(), "missing monitor must be repaired on next EnableKubernetesBindings")
+}

--- a/pkg/hook/controller/kubernetes_bindings_controller_test.go
+++ b/pkg/hook/controller/kubernetes_bindings_controller_test.go
@@ -8,8 +8,11 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/flant/kube-client/fake"
+	pkg "github.com/flant/shell-operator/pkg"
 	"github.com/flant/shell-operator/pkg/hook/config"
 	kubeeventsmanager "github.com/flant/shell-operator/pkg/kube_events_manager"
+	"github.com/flant/shell-operator/pkg/metric"
+	"github.com/flant/shell-operator/pkg/metrics"
 )
 
 const twoBindingsHookConfig = `
@@ -86,4 +89,44 @@ func TestEnableKubernetesBindings_SelfHealsMissingMonitor(t *testing.T) {
 	_, err = hc.KubernetesController.EnableKubernetesBindings()
 	g.Expect(err).ShouldNot(HaveOccurred())
 	g.Expect(mgr.HasMonitor(victim)).To(BeTrue(), "missing monitor must be repaired on next EnableKubernetesBindings")
+}
+
+// TestSnapshotsFor_MissingMonitorIsCounted ensures the empty-snapshot state is
+// observable: reading a snapshot for a configured binding whose monitor is not
+// running must increment binding_monitor_missing_total with the binding label.
+func TestSnapshotsFor_MissingMonitorIsCounted(t *testing.T) {
+	g := NewWithT(t)
+
+	fc := fake.NewFakeCluster(fake.ClusterVersionV121)
+	mgr := kubeeventsmanager.NewKubeEventsManager(context.Background(), fc.Client, log.NewNop())
+
+	var (
+		calls     int
+		gotMetric string
+		gotValue  float64
+		gotLabels map[string]string
+	)
+	storage := metric.NewStorageMock(t)
+	storage.CounterAddMock.Set(func(name string, value float64, labels map[string]string) {
+		calls++
+		gotMetric, gotValue, gotLabels = name, value, labels
+	})
+	// The storage must be set before InitKubernetesBindings: the controller
+	// captures it from the manager at init time.
+	mgr.WithMetricStorage(storage)
+
+	cfg := &config.HookConfig{}
+	g.Expect(cfg.LoadAndValidate([]byte(twoBindingsHookConfig))).ShouldNot(HaveOccurred())
+
+	hc := NewHookController()
+	hc.InitKubernetesBindings(cfg.OnKubernetesEvents, mgr, log.NewNop())
+
+	// Bindings are configured but never enabled: no monitor is running.
+	binding := cfg.OnKubernetesEvents[0].BindingName
+	g.Expect(hc.KubernetesController.SnapshotsFor(binding)).To(BeNil())
+
+	g.Expect(calls).To(Equal(1))
+	g.Expect(gotMetric).To(Equal(metrics.BindingMonitorMissingTotal))
+	g.Expect(gotValue).To(Equal(1.0))
+	g.Expect(gotLabels).To(Equal(map[string]string{pkg.MetricKeyBinding: binding}))
 }

--- a/pkg/kube_events_manager/factory.go
+++ b/pkg/kube_events_manager/factory.go
@@ -2,11 +2,13 @@ package kubeeventsmanager
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"sync"
 	"time"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
+	metricsstorage "github.com/deckhouse/deckhouse/pkg/metrics-storage"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -15,6 +17,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	pkg "github.com/flant/shell-operator/pkg"
+	"github.com/flant/shell-operator/pkg/metrics"
 )
 
 const (
@@ -40,28 +43,54 @@ type Factory struct {
 }
 
 type FactoryStore struct {
-	mu        sync.Mutex
+	mu sync.Mutex
+	// baseCtx bounds the lifetime of every shared informer in the store. The store
+	// (via its owning kubeEventsManager) is the owner of the shared factories, so
+	// their contexts must derive from the owner's context — never from the context
+	// of whichever consumer happened to create a factory first, or stopping that
+	// consumer would kill the shared informer for every other consumer.
+	baseCtx   context.Context
 	data      map[FactoryIndex]*Factory
 	stoppedCh map[FactoryIndex]chan struct{}
+	// optional, only for the factory_informer_dead_total counter
+	metricStorage metricsstorage.Storage
 }
 
-func NewFactoryStore() *FactoryStore {
+func NewFactoryStore(ctx context.Context) *FactoryStore {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	fs := &FactoryStore{
+		baseCtx:   ctx,
 		data:      make(map[FactoryIndex]*Factory),
 		stoppedCh: make(map[FactoryIndex]chan struct{}),
 	}
 	return fs
 }
 
+// WithMetricStorage sets an optional storage for the factory_informer_dead_total
+// counter. Without it a dead factory is still logged and recreated, just not counted.
+func (c *FactoryStore) WithMetricStorage(mstor metricsstorage.Storage) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.metricStorage = mstor
+}
+
 func (c *FactoryStore) Reset() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	// Stop informer goroutines before dropping the references, otherwise they
+	// keep running detached forever.
+	for _, f := range c.data {
+		f.cancel()
+	}
 	c.data = make(map[FactoryIndex]*Factory)
 	c.stoppedCh = make(map[FactoryIndex]chan struct{})
 }
 
-func (c *FactoryStore) add(ctx context.Context, index FactoryIndex, f dynamicinformer.DynamicSharedInformerFactory) {
-	ctx, cancel := context.WithCancel(ctx)
+func (c *FactoryStore) add(index FactoryIndex, f dynamicinformer.DynamicSharedInformerFactory) {
+	ctx, cancel := context.WithCancel(c.baseCtx)
 	c.data[index] = &Factory{
 		shared:               f,
 		handlerRegistrations: make(map[string]cache.ResourceEventHandlerRegistration),
@@ -74,7 +103,7 @@ func (c *FactoryStore) add(ctx context.Context, index FactoryIndex, f dynamicinf
 		slog.String(pkg.LogKeyNamespace, index.Namespace), slog.String(pkg.LogKeyGVR, index.GVR.String()))
 }
 
-func (c *FactoryStore) get(ctx context.Context, client dynamic.Interface, index FactoryIndex) *Factory {
+func (c *FactoryStore) get(client dynamic.Interface, index FactoryIndex) *Factory {
 	f, ok := c.data[index]
 	if ok {
 		log.Debug("Factory store: the factory with index found",
@@ -98,26 +127,58 @@ func (c *FactoryStore) get(ctx context.Context, client dynamic.Interface, index 
 		client, resyncPeriod, index.Namespace, tweakListOptions)
 	factory.ForResource(index.GVR)
 
-	c.add(ctx, index, factory)
+	c.add(index, factory)
 
 	return c.data[index]
 }
 
 func (c *FactoryStore) Start(ctx context.Context, informerId string, client dynamic.Interface, index FactoryIndex, handler cache.ResourceEventHandler, errorHandler *WatchErrorHandler) error {
 	c.mu.Lock()
-	defer c.mu.Unlock()
 
-	factory := c.get(ctx, client, index)
+	factory := c.get(client, index)
+
+	// A factory whose informer goroutine has already exited is unusable: event
+	// handlers can no longer be added and no events will ever be delivered, while
+	// HasSynced() on the stopped informer still returns true. Reusing it would
+	// hand the consumer a snapshot that silently never updates. Drop the corpse
+	// and build a fresh factory instead.
+	if factory.done != nil {
+		select {
+		case <-factory.done:
+			log.Warn("Factory store: informer for index is stopped, recreating factory",
+				slog.String(pkg.LogKeyNamespace, index.Namespace), slog.String(pkg.LogKeyGVR, index.GVR.String()))
+
+			// A dead factory in the store means some consumer lived with a frozen
+			// snapshot until this Start; make each detection countable.
+			if c.metricStorage != nil {
+				c.metricStorage.CounterAdd(metrics.FactoryInformerDeadTotal, 1.0, map[string]string{
+					"gvr":       index.GVR.String(),
+					"namespace": index.Namespace,
+				})
+			}
+
+			factory.cancel()
+			delete(c.data, index)
+			factory = c.get(client, index)
+		default:
+		}
+	}
 
 	informer := factory.shared.ForResource(index.GVR).Informer()
-	// Add error handler, ignore "already started" error.
-	_ = informer.SetWatchErrorHandler(errorHandler.handler)
+	// SetWatchErrorHandler fails only on an already started informer — harmless
+	// here, the handler set by the first consumer stays in effect.
+	if err := informer.SetWatchErrorHandler(errorHandler.handler); err != nil {
+		log.Debug("Factory store: watch error handler wasn't set",
+			slog.String(pkg.LogKeyNamespace, index.Namespace), slog.String(pkg.LogKeyGVR, index.GVR.String()),
+			log.Err(err))
+	}
 
 	registration, err := informer.AddEventHandler(handler)
 	if err != nil {
-		log.Warn("Factory store: couldn't add event handler to the factory's informer",
-			slog.String(pkg.LogKeyNamespace, index.Namespace), slog.String(pkg.LogKeyGVR, index.GVR.String()),
-			log.Err(err))
+		// A consumer without a registered handler would run with a snapshot that
+		// never updates — fail the start instead of degrading silently.
+		c.mu.Unlock()
+		return fmt.Errorf("add event handler for %s: %w", index.GVR.String(), err)
 	}
 
 	factory.handlerRegistrations[informerId] = registration
@@ -140,6 +201,11 @@ func (c *FactoryStore) Start(ctx context.Context, informerId string, client dyna
 		}()
 	}
 
+	c.mu.Unlock()
+
+	// Wait for the cache sync outside the store lock: a slow initial LIST of one
+	// resource must not serialize Start/Stop of every other informer (same
+	// unlock-before-wait pattern as in Stop).
 	if !informer.HasSynced() {
 		if err := wait.PollUntilContextCancel(ctx, DefaultSyncTime, true, func(_ context.Context) (bool, error) {
 			return informer.HasSynced(), nil

--- a/pkg/kube_events_manager/factory_test.go
+++ b/pkg/kube_events_manager/factory_test.go
@@ -1,0 +1,158 @@
+package kubeeventsmanager
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/flant/kube-client/fake"
+	"github.com/flant/shell-operator/pkg/metric"
+	"github.com/flant/shell-operator/pkg/metrics"
+)
+
+var configMapsGVR = schema.GroupVersionResource{Version: "v1", Resource: "configmaps"}
+
+// recordingHandler is a minimal cache.ResourceEventHandler that records names of
+// added objects.
+type recordingHandler struct {
+	mu    sync.Mutex
+	added []string
+}
+
+func (h *recordingHandler) OnAdd(obj interface{}, _ bool) {
+	u, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		return
+	}
+	h.mu.Lock()
+	h.added = append(h.added, u.GetName())
+	h.mu.Unlock()
+}
+
+func (h *recordingHandler) OnUpdate(_, _ interface{}) {}
+
+func (h *recordingHandler) OnDelete(_ interface{}) {}
+
+func (h *recordingHandler) addedNames() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]string(nil), h.added...)
+}
+
+func testWatchErrorHandler() *WatchErrorHandler {
+	return newWatchErrorHandler("factory-test", "ConfigMap", nil, nil, log.NewNop())
+}
+
+// TestFactoryStore_SurvivesConsumerContextCancel is the regression test for the
+// shared-informer lifetime bug: the factory context must derive from the store's
+// base context, not from the context of whichever consumer created the factory
+// first. Before the fix, cancelling the first consumer's context killed the
+// shared informer for every other consumer, silently freezing their snapshots.
+func TestFactoryStore_SurvivesConsumerContextCancel(t *testing.T) {
+	g := NewWithT(t)
+
+	fc := fake.NewFakeCluster(fake.ClusterVersionV121)
+	createNsWithLabels(fc, "default", map[string]string{})
+
+	store := NewFactoryStore(context.Background())
+	index := FactoryIndex{GVR: configMapsGVR, Namespace: "default"}
+
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	defer cancel1()
+
+	handler1 := &recordingHandler{}
+	g.Expect(store.Start(ctx1, "informer-1", fc.Client.Dynamic(), index, handler1, testWatchErrorHandler())).To(Succeed())
+
+	handler2 := &recordingHandler{}
+	g.Expect(store.Start(context.Background(), "informer-2", fc.Client.Dynamic(), index, handler2, testWatchErrorHandler())).To(Succeed())
+
+	// The first consumer goes away: its context is cancelled and its handler is
+	// removed — exactly what StopMonitor does for one of two hooks sharing an index.
+	cancel1()
+	store.Stop("informer-1", index)
+
+	// The shared informer must still be running for the second consumer.
+	store.mu.Lock()
+	factory, ok := store.data[index]
+	store.mu.Unlock()
+	g.Expect(ok).To(BeTrue(), "factory must stay in the store while a consumer remains")
+	select {
+	case <-factory.done:
+		t.Fatal("shared informer died together with the first consumer's context")
+	default:
+	}
+
+	// And events must still be delivered to the second consumer.
+	createCM(fc, "default", testCM("after-first-consumer-gone"))
+	g.Eventually(handler2.addedNames, "5s", "10ms").
+		Should(ContainElement("after-first-consumer-gone"),
+			"second consumer must keep receiving events after the first consumer is gone")
+}
+
+// TestFactoryStore_RecreatesDeadFactory is the regression test for the
+// success-on-corpse bug: Start on an index whose informer goroutine has already
+// exited must build a fresh factory instead of silently reusing the stopped one
+// (whose HasSynced() still returns true and which never delivers events).
+// Each detection must also increment factory_informer_dead_total.
+func TestFactoryStore_RecreatesDeadFactory(t *testing.T) {
+	g := NewWithT(t)
+
+	fc := fake.NewFakeCluster(fake.ClusterVersionV121)
+	createNsWithLabels(fc, "default", map[string]string{})
+
+	store := NewFactoryStore(context.Background())
+	index := FactoryIndex{GVR: configMapsGVR, Namespace: "default"}
+
+	var (
+		deadCounted int
+		gotLabels   map[string]string
+	)
+	storage := metric.NewStorageMock(t)
+	storage.CounterAddMock.Set(func(name string, _ float64, labels map[string]string) {
+		if name == metrics.FactoryInformerDeadTotal {
+			deadCounted++
+			gotLabels = labels
+		}
+	})
+	store.WithMetricStorage(storage)
+
+	handler1 := &recordingHandler{}
+	g.Expect(store.Start(context.Background(), "informer-1", fc.Client.Dynamic(), index, handler1, testWatchErrorHandler())).To(Succeed())
+
+	// Kill the informer out of band, keeping the factory in the store — the state
+	// the pre-fix lifetime bug used to leave behind.
+	store.mu.Lock()
+	dead := store.data[index]
+	store.mu.Unlock()
+	dead.cancel()
+	<-dead.done
+
+	handler2 := &recordingHandler{}
+	g.Expect(store.Start(context.Background(), "informer-2", fc.Client.Dynamic(), index, handler2, testWatchErrorHandler())).To(Succeed())
+
+	store.mu.Lock()
+	fresh, ok := store.data[index]
+	store.mu.Unlock()
+	g.Expect(ok).To(BeTrue())
+	g.Expect(fresh).ToNot(BeIdenticalTo(dead), "a dead factory must be replaced, not reused")
+	select {
+	case <-fresh.done:
+		t.Fatal("recreated factory is not running")
+	default:
+	}
+
+	createCM(fc, "default", testCM("after-recreate"))
+	g.Eventually(handler2.addedNames, "5s", "10ms").
+		Should(ContainElement("after-recreate"), "consumer on the recreated factory must receive events")
+
+	g.Expect(deadCounted).To(Equal(1), "each dead-factory detection must be counted")
+	g.Expect(gotLabels).To(Equal(map[string]string{
+		"gvr":       index.GVR.String(),
+		"namespace": index.Namespace,
+	}))
+}

--- a/pkg/kube_events_manager/kube_events_manager.go
+++ b/pkg/kube_events_manager/kube_events_manager.go
@@ -75,7 +75,7 @@ func NewKubeEventsManager(ctx context.Context, client *klient.Client, logger *lo
 		ctx:          cctx,
 		cancel:       cancel,
 		KubeClient:   client,
-		factoryStore: NewFactoryStore(),
+		factoryStore: NewFactoryStore(cctx),
 		m:            sync.RWMutex{},
 		Monitors:     make(map[string]Monitor),
 		KubeEventCh:  make(chan kemtypes.KubeEvent, 1),
@@ -86,6 +86,7 @@ func NewKubeEventsManager(ctx context.Context, client *klient.Client, logger *lo
 
 func (mgr *kubeEventsManager) WithMetricStorage(mstor metricsstorage.Storage) {
 	mgr.metricStorage = mstor
+	mgr.factoryStore.WithMetricStorage(mstor)
 }
 
 // AddMonitor creates a monitor with informers and return a KubeEvent with existing objects.

--- a/pkg/kube_events_manager/monitor_test.go
+++ b/pkg/kube_events_manager/monitor_test.go
@@ -58,7 +58,7 @@ func Test_Monitor_should_handle_dynamic_ns_events(t *testing.T) {
 	metricStorage.GaugeSetMock.When(metrics.KubeSnapshotObjects, 2, map[string]string(nil)).Then()
 	metricStorage.GaugeSetMock.When(metrics.KubeSnapshotObjects, 3, map[string]string(nil)).Then()
 
-	mon := NewMonitor(context.Background(), fc.Client, metricStorage, NewFactoryStore(), monitorCfg, func(ev kemtypes.KubeEvent) {
+	mon := NewMonitor(context.Background(), fc.Client, metricStorage, NewFactoryStore(context.Background()), monitorCfg, func(ev kemtypes.KubeEvent) {
 		objsMutex.Lock()
 		objsFromEvents = append(objsFromEvents, snapshotResourceIDs(ev.Objects)...)
 		objsMutex.Unlock()

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -92,6 +92,10 @@ var (
 	// monitors (e.g. a Disable/Enable race) until the next EnableKubernetesBindings
 	// repairs them.
 	BindingMonitorMissingTotal = "{PREFIX}binding_monitor_missing_total"
+	// FactoryInformerDeadTotal counts dead shared informer factories detected and
+	// recreated by FactoryStore.Start. Non-zero values mean some consumers lived
+	// with a frozen snapshot until the recreation.
+	FactoryInformerDeadTotal = "{PREFIX}factory_informer_dead_total"
 )
 
 // ReplacePrefix replaces the {PREFIX} placeholder in a metric name with the provided prefix.
@@ -128,6 +132,7 @@ type Names struct {
 	KubeEventDurationSeconds                string
 	KubernetesClientWatchErrorsTotal        string
 	BindingMonitorMissingTotal              string
+	FactoryInformerDeadTotal                string
 }
 
 // NewNames builds a *Names with prefix substituted into every metric template.
@@ -170,6 +175,7 @@ func NewNames(prefix string) *Names {
 		KubeEventDurationSeconds:                tpl(KubeEventDurationSeconds, "kube_event_duration_seconds"),
 		KubernetesClientWatchErrorsTotal:        tpl(KubernetesClientWatchErrorsTotal, "kubernetes_client_watch_errors_total"),
 		BindingMonitorMissingTotal:              tpl(BindingMonitorMissingTotal, "binding_monitor_missing_total"),
+		FactoryInformerDeadTotal:                tpl(FactoryInformerDeadTotal, "factory_informer_dead_total"),
 	}
 }
 
@@ -220,6 +226,7 @@ func InitMetrics(prefix string) {
 	KubeEventDurationSeconds = ReplacePrefix(KubeEventDurationSeconds, prefix)
 	KubernetesClientWatchErrorsTotal = ReplacePrefix(KubernetesClientWatchErrorsTotal, prefix)
 	BindingMonitorMissingTotal = ReplacePrefix(BindingMonitorMissingTotal, prefix)
+	FactoryInformerDeadTotal = ReplacePrefix(FactoryInformerDeadTotal, prefix)
 }
 
 // ============================================================================
@@ -507,6 +514,15 @@ func RegisterKubeEventsManagerMetrics(metricStorage metricsstorage.Storage, labe
 	)
 	if err != nil {
 		return fmt.Errorf("failed to register %s: %w", BindingMonitorMissingTotal, err)
+	}
+
+	// Register dead informer factory counter
+	_, err = metricStorage.RegisterCounter(
+		FactoryInformerDeadTotal, []string{"gvr", "namespace"},
+		options.WithHelp("Counter of dead shared informer factories detected and recreated on Start"),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to register %s: %w", FactoryInformerDeadTotal, err)
 	}
 
 	return nil

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -86,6 +86,12 @@ var (
 	KubeEventDurationSeconds = "{PREFIX}kube_event_duration_seconds"
 	// KubernetesClientWatchErrorsTotal counts Kubernetes client watch errors
 	KubernetesClientWatchErrorsTotal = "{PREFIX}kubernetes_client_watch_errors_total"
+	// BindingMonitorMissingTotal counts snapshot reads for a configured kubernetes
+	// binding whose monitor is not running: the hook receives an empty snapshot
+	// instead of real cluster state. Non-zero values indicate lost or never-started
+	// monitors (e.g. a Disable/Enable race) until the next EnableKubernetesBindings
+	// repairs them.
+	BindingMonitorMissingTotal = "{PREFIX}binding_monitor_missing_total"
 )
 
 // ReplacePrefix replaces the {PREFIX} placeholder in a metric name with the provided prefix.
@@ -121,6 +127,7 @@ type Names struct {
 	KubeJqFilterDurationSeconds             string
 	KubeEventDurationSeconds                string
 	KubernetesClientWatchErrorsTotal        string
+	BindingMonitorMissingTotal              string
 }
 
 // NewNames builds a *Names with prefix substituted into every metric template.
@@ -162,6 +169,7 @@ func NewNames(prefix string) *Names {
 		KubeJqFilterDurationSeconds:             tpl(KubeJqFilterDurationSeconds, "kube_jq_filter_duration_seconds"),
 		KubeEventDurationSeconds:                tpl(KubeEventDurationSeconds, "kube_event_duration_seconds"),
 		KubernetesClientWatchErrorsTotal:        tpl(KubernetesClientWatchErrorsTotal, "kubernetes_client_watch_errors_total"),
+		BindingMonitorMissingTotal:              tpl(BindingMonitorMissingTotal, "binding_monitor_missing_total"),
 	}
 }
 
@@ -211,6 +219,7 @@ func InitMetrics(prefix string) {
 	KubeJqFilterDurationSeconds = ReplacePrefix(KubeJqFilterDurationSeconds, prefix)
 	KubeEventDurationSeconds = ReplacePrefix(KubeEventDurationSeconds, prefix)
 	KubernetesClientWatchErrorsTotal = ReplacePrefix(KubernetesClientWatchErrorsTotal, prefix)
+	BindingMonitorMissingTotal = ReplacePrefix(BindingMonitorMissingTotal, prefix)
 }
 
 // ============================================================================
@@ -489,6 +498,15 @@ func RegisterKubeEventsManagerMetrics(metricStorage metricsstorage.Storage, labe
 	)
 	if err != nil {
 		return fmt.Errorf("failed to register %s: %w", KubernetesClientWatchErrorsTotal, err)
+	}
+
+	// Register missing binding monitor counter
+	_, err = metricStorage.RegisterCounter(
+		BindingMonitorMissingTotal, []string{"binding"},
+		options.WithHelp("Counter of snapshot reads for a configured kubernetes binding without a live monitor (the hook got an empty snapshot)"),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to register %s: %w", BindingMonitorMissingTotal, err)
 	}
 
 	return nil

--- a/pkg/shell-operator/manager_events_handler.go
+++ b/pkg/shell-operator/manager_events_handler.go
@@ -2,6 +2,8 @@ package shell_operator
 
 import (
 	"context"
+	"log/slog"
+	"runtime/debug"
 	"sync"
 	"sync/atomic"
 
@@ -83,12 +85,16 @@ func (m *ManagerEventsHandler) Start() {
 				select {
 				case crontab := <-m.scheduleManager.Ch():
 					if m.scheduleCb != nil {
-						tailTasks = m.scheduleCb(m.ctx, crontab)
+						tailTasks = runEventCb(logEntry, "schedule", func() []task.Task {
+							return m.scheduleCb(m.ctx, crontab)
+						})
 					}
 
 				case kubeEvent := <-m.kubeEventsManager.Ch():
 					if m.kubeEventCb != nil {
-						tailTasks = m.kubeEventCb(m.ctx, kubeEvent)
+						tailTasks = runEventCb(logEntry, "kubernetes", func() []task.Task {
+							return m.kubeEventCb(m.ctx, kubeEvent)
+						})
 					}
 
 				case <-m.ctx.Done():
@@ -100,6 +106,25 @@ func (m *ManagerEventsHandler) Start() {
 			}
 		}()
 	})
+}
+
+// runEventCb invokes an event callback with panic isolation, mirroring the
+// recover in TaskQueue.processOne: a panicking hook dispatch must not kill
+// the events goroutine and with it the whole process. On panic the event's
+// tail tasks are dropped and nil is returned.
+func runEventCb(logEntry *log.Logger, binding string, cb func() []task.Task) []task.Task {
+	defer func() {
+		if r := recover(); r != nil {
+			logEntry.Warn(
+				"panic recovered in ManagerEventsHandler",
+				slog.String(pkg.LogKeyBinding, binding),
+				slog.Any(pkg.LogKeyError, r),
+				slog.String(pkg.LogKeyStack, string(debug.Stack())),
+			)
+		}
+	}()
+
+	return cb()
 }
 
 // Stop signals the events handler loop to exit. Stop is non-blocking; pair it

--- a/pkg/shell-operator/manager_events_handler_test.go
+++ b/pkg/shell-operator/manager_events_handler_test.go
@@ -1,0 +1,99 @@
+package shell_operator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
+	"github.com/stretchr/testify/require"
+
+	kemtypes "github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	"github.com/flant/shell-operator/pkg/task"
+	"github.com/flant/shell-operator/pkg/task/queue"
+)
+
+type fakeKubeEventEmitter struct {
+	ch chan kemtypes.KubeEvent
+}
+
+func (f *fakeKubeEventEmitter) Ch() chan kemtypes.KubeEvent { return f.ch }
+
+type fakeScheduleEmitter struct {
+	ch chan string
+}
+
+func (f *fakeScheduleEmitter) Ch() chan string { return f.ch }
+
+func newTestEventsHandler(kubeCh chan kemtypes.KubeEvent, schedCh chan string) *ManagerEventsHandler {
+	return newManagerEventsHandler(context.Background(), &managerEventsHandlerConfig{
+		tqs:    queue.NewTaskQueueSet(),
+		mgr:    &fakeKubeEventEmitter{ch: kubeCh},
+		smgr:   &fakeScheduleEmitter{ch: schedCh},
+		logger: log.NewNop(),
+	})
+}
+
+// TestManagerEventsHandlerSurvivesPanicInKubeEventCb proves the panic
+// escalation bug: a panic inside the kube-event callback (in production - the
+// nil HookController dereference during hook dispatch) must not kill the
+// events goroutine and the whole process. The handler has to log the panic
+// and keep processing subsequent events.
+//
+// On unfixed code this test crashes the whole test binary - that crash is the
+// process-level SIGSEGV from the incident, reproduced in miniature.
+func TestManagerEventsHandlerSurvivesPanicInKubeEventCb(t *testing.T) {
+	kubeCh := make(chan kemtypes.KubeEvent)
+	m := newTestEventsHandler(kubeCh, make(chan string))
+
+	processed := make(chan string, 1)
+	m.WithKubeEventHandler(func(_ context.Context, ev kemtypes.KubeEvent) []task.Task {
+		if ev.MonitorId == "panic" {
+			panic("runtime error: invalid memory address or nil pointer dereference")
+		}
+		processed <- ev.MonitorId
+		return nil
+	})
+
+	m.Start()
+	defer m.Stop()
+
+	kubeCh <- kemtypes.KubeEvent{MonitorId: "panic"}
+	kubeCh <- kemtypes.KubeEvent{MonitorId: "after-panic"}
+
+	select {
+	case got := <-processed:
+		require.Equal(t, "after-panic", got)
+	case <-time.After(5 * time.Second):
+		t.Fatal("events goroutine died after panic: second event was never processed")
+	}
+}
+
+// TestManagerEventsHandlerSurvivesPanicInScheduleCb covers the same panic
+// isolation for the schedule callback branch.
+func TestManagerEventsHandlerSurvivesPanicInScheduleCb(t *testing.T) {
+	schedCh := make(chan string)
+	m := newTestEventsHandler(make(chan kemtypes.KubeEvent), schedCh)
+
+	processed := make(chan string, 1)
+	m.WithScheduleEventHandler(func(_ context.Context, crontab string) []task.Task {
+		if crontab == "panic" {
+			panic("schedule hook dispatch failed")
+		}
+		processed <- crontab
+		return nil
+	})
+
+	m.Start()
+	defer m.Stop()
+
+	schedCh <- "panic"
+	schedCh <- "* * * * *"
+
+	select {
+	case got := <-processed:
+		require.Equal(t, "* * * * *", got)
+	case <-time.After(5 * time.Second):
+		t.Fatal("events goroutine died after panic: second event was never processed")
+	}
+}


### PR DESCRIPTION
#### Overview

Four changes, one per commit:

1. Wraps the kube-event and schedule callbacks in `ManagerEventsHandler.Start` with `recover` (new `runEventCb` helper), mirroring the existing recover in `TaskQueue.processOne`. A panic inside a callback is logged with the binding name and stack, the event's tail tasks are dropped, and the events goroutine keeps processing.
2. Makes `EnableKubernetesBindings` idempotent and self-healing (ported from the release-1.76 fix, flant/shell-operator#923): the `alreadyEnabled` early-return is removed, a Synchronization `BindingExecutionInfo` is emitted for every binding on every call, and a binding whose link exists but whose monitor is gone (Disable/Enable race) gets its monitor re-created and re-started. Deduplication of repeated Synchronization runs stays on the caller side (addon-operator tracks it via `SynchronizationState`).
3. Makes the "configured binding without a live monitor" state observable: `SnapshotsFor` logs it at Error level and increments the new `{PREFIX}binding_monitor_missing_total{binding}` counter (`shell_operator_` prefix in standalone shell-operator). This state is exactly how a lost or never-started monitor silently feeds empty snapshots into a hook that still "succeeds".
4. Fixes the shared informer factory lifetime (port of the `FactoryStore` part of #923, released in v1.17.7 and already running in deckhouse release-1.76 via deckhouse/deckhouse#21255):
   - factory contexts derive from the store's base context (the owning `kubeEventsManager`), not from the first consumer's context - stopping the first consumer no longer kills the shared informer for everyone else;
   - `Start` detects a factory whose informer goroutine has exited, drops it and builds a fresh one instead of silently reusing a corpse whose `HasSynced()` is still true;
   - `AddEventHandler` failure fails `Start` instead of a Warn with a nil registration;
   - `Reset()` cancels factories before dropping references; the cache-sync poll runs outside the store lock;
   - each dead-factory detection increments the new `{PREFIX}factory_informer_dead_total{gvr,namespace}` counter (extension over the 1.17 port).

#### What this PR does / why we need it

The events goroutine had no `recover`, so a panic inside `kubeEventCb` / `scheduleCb` killed the whole process. In production this made deckhouse-controller crash with SIGSEGV: a hook registration defect in addon-operator left orphan module hooks with a nil `*HookController` in the hook index, and the kube-events dispatcher called `CanHandleKubeEvent` on the nil receiver. The identical panic arriving through the task queue was recovered and logged as a warn; the one arriving through this goroutine took down the operator (incidents on 2026-06-30 and 2026-05-05, the latter with ~407 restarts).

The root cause is fixed separately in flant/addon-operator#797. This change is the defense-in-depth layer: no single hook dispatch panic, present or future, should escalate to a full operator crash while the task-queue path already tolerates it.

The `EnableKubernetesBindings` change fixes the second incident mechanism (2026-07-08): after a partial failure (one hook's monitor could not start), the retried call hit the `alreadyEnabled` early-return and yielded ZERO Synchronization contexts, so the module's hooks never received the values-populating Synchronization run - kubernetes bindings stayed empty and events stayed locked while the module reported success. The same early-return also made the "link present, monitor gone" state left by a `DisableModuleHooks` racing with the queue worker permanent: snapshots read as empty forever, with no error anywhere.

**Before:** any panic in a kube-event or schedule callback kills the whole shell-operator process; a retried `EnableKubernetesBindings` silently drops the Synchronization run; a lost monitor feeds empty snapshots forever with no signal.
**After:** the panic is recovered and logged ("panic recovered in ManagerEventsHandler" with binding and stack), event processing continues; every `EnableKubernetesBindings` call emits Synchronization contexts and repairs missing monitors; a snapshot read without a live monitor produces an Error log and increments `binding_monitor_missing_total`.

#### Special notes for your reviewer

- On panic `runEventCb` returns nil tail tasks; `AddTailTasks` with an empty list is a no-op, so non-panicking paths are unchanged.
- New tests, all pass under `-race`:
  - `TestManagerEventsHandlerSurvivesPanicInKubeEventCb` / `...InScheduleCb` - on unfixed code they crash the whole test binary, the incident in miniature
  - `TestEnableKubernetesBindings_RepeatCallStillEmitsSynchronization` - regression: the second call used to return 0 contexts
  - `TestEnableKubernetesBindings_SelfHealsMissingMonitor` - the Disable/Enable race state is repaired by the next enable
  - `TestSnapshotsFor_MissingMonitorIsCounted` - the counter fires with the `binding` label
- Monitor creation idempotency is per-binding (`!linked || !HasMonitor`), so the removed method-level early-return does not reintroduce duplicate monitors.
- The metric storage reaches the bindings controller via an optional accessor on the kube events manager; no public constructor or interface signatures change, callers without a storage just get the Error log.
- Semantics change for library consumers: `EnableKubernetesBindings` now returns Synchronization infos on every call (previously only the first). addon-operator handles repeated runs via `SynchronizationState`; flag this in the changelog.
- API change for library consumers: `NewFactoryStore()` becomes `NewFactoryStore(ctx)` - same signature change that already shipped upstream in v1.17.7. Decide whether main releases this as v1.20.2 or v1.21.0.
- The factory port is byte-identical to the reviewed v1.17.7 code except the added metric; new tests `TestFactoryStore_SurvivesConsumerContextCancel` and `TestFactoryStore_RecreatesDeadFactory` are ported as-is (the latter extended with the metric assertion). Known gap, same as upstream: no unit test forces the `AddEventHandler` error path (needs a stopped informer injected between the corpse check and handler registration).
- Follow-up worth a look after this lands: `WaitStopped` semantics (a live factory returns instantly via an already-closed channel) predate this change and may deserve a revisit now that factories no longer die with their first consumer.
- Companion PRs: flant/addon-operator#797 (root-cause fix, pins this branch as a pseudo-version), deckhouse/deckhouse#21201 (bump + live A/B fault-injection verification on a dev cluster), deckhouse/deckhouse#21255 (release-1.76 bump carrying the same fixes as v1.17.7/v1.21.19).
