### PR TITLE
[shell-operator] fix: patch CRD conversion without overwriting fields

### DIFF
--- a/pkg/webhook/conversion/crd_client_config.go
+++ b/pkg/webhook/conversion/crd_client_config.go
@@ -2,11 +2,12 @@ package conversion
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	klient "github.com/flant/kube-client/client"
 	"github.com/flant/shell-operator/pkg"
@@ -24,48 +25,52 @@ type CrdClientConfig struct {
 
 var SupportedConversionReviewVersions = []string{"v1", "v1beta1"}
 
-func (c *CrdClientConfig) Update(ctx context.Context) error {
+// PatchConversion points spec.conversion of the CRD at this operator's webhook
+// server, leaving every other field of the CRD alone.
+func (c *CrdClientConfig) PatchConversion(ctx context.Context) error {
 	var (
 		retryTimeout = 15 * time.Second
 		retryBudget  = 60 // 60 times * 15 sec = 15 min
 		client       = c.KubeClient
 	)
 
-tryToGetCRD:
-	crd, err := client.ApiExt().CustomResourceDefinitions().Get(ctx, c.CrdName, metav1.GetOptions{})
+	conv, err := json.Marshal(&extv1.CustomResourceConversion{
+		Strategy: extv1.WebhookConverter,
+		Webhook: &extv1.WebhookConversion{
+			ClientConfig: &extv1.WebhookClientConfig{
+				Service: &extv1.ServiceReference{
+					Namespace: c.Namespace,
+					Name:      c.ServiceName,
+					Path:      &c.Path,
+				},
+				CABundle: c.CABundle,
+			},
+			ConversionReviewVersions: SupportedConversionReviewVersions,
+		},
+	})
 	if err != nil {
-		if retryBudget > 0 {
-			retryBudget--
-			time.Sleep(retryTimeout)
-			goto tryToGetCRD
+		return fmt.Errorf("marshal conversion: %w", err)
+	}
+
+	patch := []byte(`[{"op":"add","path":"/spec/conversion","value":` + string(conv) + `}]`)
+
+	// The CRD is often absent when a hook registers its conversion bindings, so the
+	// patch is retried on the budget the Get used to hold.
+	for {
+		_, err = client.ApiExt().CustomResourceDefinitions().Patch(ctx, c.CrdName, types.JSONPatchType, patch, pkg.DefaultPatchOptions())
+		if err == nil {
+			return nil
 		}
 
-		return fmt.Errorf("get CRD: %w", err)
-	}
+		if retryBudget == 0 {
+			return fmt.Errorf("patch CRD conversion: %w", err)
+		}
+		retryBudget--
 
-	if crd.Spec.Conversion == nil {
-		crd.Spec.Conversion = new(extv1.CustomResourceConversion)
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("patch CRD conversion: %w", ctx.Err())
+		case <-time.After(retryTimeout):
+		}
 	}
-	crd.Spec.Conversion.Strategy = extv1.WebhookConverter
-
-	if crd.Spec.Conversion.Webhook == nil {
-		crd.Spec.Conversion.Webhook = new(extv1.WebhookConversion)
-	}
-	crd.Spec.Conversion.Webhook.ClientConfig = &extv1.WebhookClientConfig{
-		URL: nil,
-		Service: &extv1.ServiceReference{
-			Namespace: c.Namespace,
-			Name:      c.ServiceName,
-			Path:      &c.Path,
-		},
-		CABundle: c.CABundle,
-	}
-	crd.Spec.Conversion.Webhook.ConversionReviewVersions = SupportedConversionReviewVersions
-
-	_, err = client.ApiExt().CustomResourceDefinitions().Update(ctx, crd, pkg.DefaultUpdateOptions())
-	if err != nil {
-		return fmt.Errorf("update CRD: %w", err)
-	}
-
-	return nil
 }

--- a/pkg/webhook/conversion/crd_client_config.go
+++ b/pkg/webhook/conversion/crd_client_config.go
@@ -31,7 +31,6 @@ func (c *CrdClientConfig) PatchConversion(ctx context.Context) error {
 	var (
 		retryTimeout = 15 * time.Second
 		retryBudget  = 60 // 60 times * 15 sec = 15 min
-		client       = c.KubeClient
 	)
 
 	conv, err := json.Marshal(&extv1.CustomResourceConversion{
@@ -57,7 +56,7 @@ func (c *CrdClientConfig) PatchConversion(ctx context.Context) error {
 	// The CRD is often absent when a hook registers its conversion bindings, so the
 	// patch is retried on the budget the Get used to hold.
 	for {
-		_, err = client.ApiExt().CustomResourceDefinitions().Patch(ctx, c.CrdName, types.JSONPatchType, patch, pkg.DefaultPatchOptions())
+		_, err = c.KubeClient.ApiExt().CustomResourceDefinitions().Patch(ctx, c.CrdName, types.JSONPatchType, patch, pkg.DefaultPatchOptions())
 		if err == nil {
 			return nil
 		}

--- a/pkg/webhook/conversion/manager.go
+++ b/pkg/webhook/conversion/manager.go
@@ -94,9 +94,9 @@ func (m *WebhookManager) Start() error {
 	}
 
 	for _, clientCfg := range m.ClientConfigs {
-		err = clientCfg.Update(ctx)
+		err = clientCfg.PatchConversion(ctx)
 		if err != nil {
-			return fmt.Errorf("update CRD: %w", err)
+			return fmt.Errorf("patch CRD conversion: %w", err)
 		}
 	}
 


### PR DESCRIPTION
## Description

Replace the read-modify-write update of the CRD in the conversion webhook manager with a JSON Patch that touches only `spec.conversion`.

`CrdClientConfig.Update()` used to `Get()` the whole `CustomResourceDefinition`, mutate `spec.conversion` in memory and `Update()` the entire object back. It is now `CrdClientConfig.PatchConversion()`, which marshals the desired `CustomResourceConversion` (webhook strategy, service reference, CA bundle, supported review versions) and sends a single `[{"op":"add","path":"/spec/conversion","value":{…}}]` patch.

Other changes that come with it:

- The retry budget (60 attempts × 15s = 15 min) now wraps the write call instead of only the `Get`, so a CRD that does not exist yet when a hook registers its conversion binding is still picked up once it appears.
- The retry sleep is `select`-based on `ctx.Done()` instead of a blocking `time.Sleep()`, so the loop stops on context cancellation instead of holding startup for up to 15 minutes.
- The method and the error messages are renamed to reflect what actually happens (`update CRD` → `patch CRD conversion`).

## Why do we need it, and what problem does it solve?

Sending the full CRD back on `Update()` makes shell-operator a last-write-wins writer for the *entire* object. Anything written to that CRD between our `Get()` and our `Update()` — by Helm, by another controller, by an operator that owns the same CRD, or by a parallel shell-operator instance — is silently reverted to the snapshot we read, and the change is not limited to `spec.conversion`: schema edits, versions, labels and annotations all travel in that request. On a busy cluster this shows up as CRD fields mysteriously rolling back right after the operator starts, and as `the object has been modified` conflicts on startup.

A JSON Patch scoped to `/spec/conversion` states the actual intent — "point this CRD's conversion at my webhook, leave everything else alone" — so the operator can no longer clobber fields it does not own, and concurrent writers to other parts of the CRD stop conflicting with it.

The second problem was retry placement: only the `Get` was retried, so a CRD that appeared during startup was fetched successfully but the very first failing write aborted `WebhookManager.Start()`. Retrying the write instead covers the real race (the CRD being created around the same time as the operator), and making the wait
context-aware means a shutdown during that window no longer blocks for minutes.