### PR TITLE
feat: expose reinvocationPolicy on kubernetesMutating bindings

### DIFF
--- a/pkg/hook/config/config_test.go
+++ b/pkg/hook/config/config_test.go
@@ -615,6 +615,72 @@ kubernetesValidating:
 			},
 		},
 		{
+			"v1 kubernetesMutating reinvocationPolicy",
+			`
+configVersion: v1
+kubernetesMutating:
+- name: default.example.com
+  rules:
+  - apiVersions: ["v1"]
+    apiGroups: ["crd-domain.io"]
+    resources: ["MyCustomResource"]
+    operations: ["*"]
+- name: reinvoke.example.com
+  reinvocationPolicy: IfNeeded
+  rules:
+  - apiVersions: ["v1"]
+    apiGroups: ["crd-domain.io"]
+    resources: ["MyCustomResource"]
+    operations: ["*"]
+`,
+			func() {
+				g.Expect(err).ShouldNot(HaveOccurred())
+				g.Expect(hookConfig.KubernetesMutating).Should(HaveLen(2))
+
+				// Unset: nil, so apiserver defaults to Never.
+				g.Expect(hookConfig.KubernetesMutating[0].Webhook.ReinvocationPolicy).Should(BeNil())
+
+				// Set: passed through.
+				rp := hookConfig.KubernetesMutating[1].Webhook.ReinvocationPolicy
+				g.Expect(rp).ShouldNot(BeNil())
+				g.Expect(*rp).To(Equal(v1.IfNeededReinvocationPolicy))
+			},
+		},
+		{
+			"v1 kubernetesMutating reinvocationPolicy invalid",
+			`
+configVersion: v1
+kubernetesMutating:
+- name: bad.example.com
+  reinvocationPolicy: Sometimes
+  rules:
+  - apiVersions: ["v1"]
+    apiGroups: ["crd-domain.io"]
+    resources: ["MyCustomResource"]
+    operations: ["*"]
+`,
+			func() {
+				g.Expect(err).Should(HaveOccurred())
+			},
+		},
+		{
+			"v1 kubernetesValidating rejects reinvocationPolicy",
+			`
+configVersion: v1
+kubernetesValidating:
+- name: nope.example.com
+  reinvocationPolicy: Never
+  rules:
+  - apiVersions: ["v1"]
+    apiGroups: ["crd-domain.io"]
+    resources: ["MyCustomResource"]
+    operations: ["*"]
+`,
+			func() {
+				g.Expect(err).Should(HaveOccurred())
+			},
+		},
+		{
 			"v1 kubernetesValidating name error",
 			`
 configVersion: v1

--- a/pkg/hook/config/config_v1.go
+++ b/pkg/hook/config/config_v1.go
@@ -83,6 +83,9 @@ type KubernetesAdmissionConfigV1 struct {
 	SideEffects          *v1.SideEffectClass      `json:"sideEffects"`
 	TimeoutSeconds       *int32                   `json:"timeoutSeconds,omitempty"`
 	MatchConditions      []v1.MatchCondition      `json:"matchConditions,omitempty"`
+	// ReinvocationPolicy is honored only for kubernetesMutating; the schema
+	// rejects it on kubernetesValidating (the k8s type has no such field).
+	ReinvocationPolicy *v1.ReinvocationPolicyType `json:"reinvocationPolicy,omitempty"`
 }
 
 // version 1 of kubernetes conversion configuration
@@ -517,6 +520,8 @@ func convertMutating(cfgV1 KubernetesAdmissionConfigV1) htypes.MutatingConfig {
 	}
 
 	webhook.MatchConditions = cfgV1.MatchConditions
+
+	webhook.ReinvocationPolicy = cfgV1.ReinvocationPolicy
 
 	cfg.Webhook = &admission.MutatingWebhookConfig{
 		MutatingWebhook: webhook,

--- a/pkg/hook/config/schemas.go
+++ b/pkg/hook/config/schemas.go
@@ -230,6 +230,11 @@ properties:
         timeoutSeconds:
           type: integer
           example: 10
+        reinvocationPolicy:
+          type: string
+          enum:
+          - Never
+          - IfNeeded
         matchConditions:
           type: array
           items:


### PR DESCRIPTION
#### Overview

Wire `reinvocationPolicy` from `admissionregistration.k8s.io/v1 MutatingWebhook` through hook config, so hook authors can opt into `IfNeeded` when their mutation depends on the object state after other mutators run.

#### What this PR does / why we need it

PR #439 landed mutating-webhook support but did not surface the `reinvocationPolicy` knob. Without it, every mutating hook registered via shell-operator gets the API server default (`Never`), and there's no config-level way to change that — you'd have to hand-patch the generated `MutatingWebhookConfiguration`.

This adds an optional `reinvocationPolicy: Never|IfNeeded` field on `kubernetesMutating` entries and maps it into `v1.MutatingWebhook.ReinvocationPolicy`. When unset the field stays nil, so the API server keeps owning the default (no behavior change for existing hooks).

Example:

```yaml
configVersion: v1
kubernetesMutating:
- name: default-replicas.example.com
  reinvocationPolicy: IfNeeded
  rules:
  - operations: ["CREATE"]
    apiGroups:    ["stable.example.com"]
    apiVersions:  ["v1"]
    resources:    ["crontabs"]
```

Changes:

- `pkg/hook/config/config_v1.go` — new `ReinvocationPolicy *v1.ReinvocationPolicyType` on `KubernetesAdmissionConfigV1`; passed through in `convertMutating`.
- `pkg/hook/config/schemas.go` — `reinvocationPolicy` enum added under `kubernetesMutating` only. The knob does not exist on `ValidatingWebhook` (validating webhooks run once, after all mutations), and `additionalProperties: false` already rejects it on `kubernetesValidating`.
- `pkg/hook/config/config_test.go` — three cases: pass-through (`IfNeeded` and unset), invalid enum rejected, and rejection on `kubernetesValidating`.

Docs are not touched — there is no `BINDING_MUTATING.md` in the repo yet (the mutating example already references a missing file); that gap is out of scope here.

#### Does this PR introduce a user-facing change?

```release-note
Add `reinvocationPolicy` field on `kubernetesMutating` hook bindings to control MutatingWebhook reinvocation.
```